### PR TITLE
Exclude FakeDb from coverage

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,8 @@ jobs:
         run: |
           dotnet test --no-build --configuration Release \
             --collect:"XPlat Code Coverage" \
-            --results-directory ./TestResults
+            --results-directory ./TestResults \
+            -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[pengdows.crud.fakeDb]*"
           
       - name: Generate coverage report
         run: |
@@ -44,7 +45,7 @@ jobs:
             -reports:TestResults/**/coverage.cobertura.xml \
             -targetdir:coverage-report \
             -reporttypes:HtmlSummary \
-            -assemblyfilters:+pengdows.crud.*,-pengdows.crud.testbed
+            -assemblyfilters:+pengdows.crud.*,-pengdows.crud.testbed,-pengdows.crud.fakeDb
           
           grep -oPm1 "(?<=<assembly name=\")[^\"]+" TestResults/**/coverage.cobertura.xml | sort | uniq
         

--- a/pengdows.crud.fakeDb/AssemblyInfo.cs
+++ b/pengdows.crud.fakeDb/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: ExcludeFromCodeCoverage]


### PR DESCRIPTION
## Summary
- add `ExcludeFromCodeCoverage` to FakeDb project
- exclude FakeDb from test coverage collection and report

## Testing
- `dotnet test pengdows.crud.Tests/pengdows.crud.Tests.csproj --no-build --verbosity normal` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68584e3f2414832baa0dcef03295dcf5