### PR TITLE
Replace console output with structured logging

### DIFF
--- a/pengdows.crud.Tests/DataSourceInformationTests.cs
+++ b/pengdows.crud.Tests/DataSourceInformationTests.cs
@@ -6,6 +6,7 @@ using System.Data;
 using System.Linq;
 using pengdows.crud.enums;
 using pengdows.crud.FakeDb;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 #endregion
@@ -70,7 +71,7 @@ public class DataSourceInformationTests
         var conn = new FakeTrackedConnection(x, schema, scalars);
 
         // Act
-        var info = DataSourceInformation.Create(conn);
+        var info = DataSourceInformation.Create(conn, NullLoggerFactory.Instance);
 
         // Assert: product detection
         //Assert.Equal(db, info.Product);

--- a/pengdows.crud.Tests/IDataSourceInformationTests.cs
+++ b/pengdows.crud.Tests/IDataSourceInformationTests.cs
@@ -1,6 +1,7 @@
 #region
 
 using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 #endregion
@@ -13,7 +14,7 @@ public class IDataSourceInformationTests
     public void IDataSourceInformation_ImplementsRequiredProperties()
     {
         using var conn = new SqliteConnection("Data Source=:memory:");
-        var info = new DataSourceInformation(conn);
+        var info = new DataSourceInformation(conn, NullLoggerFactory.Instance);
         Assert.False(string.IsNullOrWhiteSpace(info.CompositeIdentifierSeparator));
         Assert.False(string.IsNullOrWhiteSpace(info.ParameterMarker));
     }

--- a/pengdows.crud/DatabaseContext.cs
+++ b/pengdows.crud/DatabaseContext.cs
@@ -20,6 +20,7 @@ namespace pengdows.crud;
 public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext
 {
     private readonly DbProviderFactory _factory;
+    private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<IDatabaseContext> _logger;
     private bool _applyConnectionSessionSettings;
     private ITrackedConnection? _connection = null;
@@ -82,8 +83,8 @@ public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext
     {
         try
         {
-            loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
-            _logger = loggerFactory?.CreateLogger<IDatabaseContext>() ?? NullLogger<IDatabaseContext>.Instance;
+            _loggerFactory = loggerFactory ?? NullLoggerFactory.Instance;
+            _logger = _loggerFactory.CreateLogger<IDatabaseContext>();
             ReadWriteMode = configuration.ReadWriteMode;
             TypeMapRegistry = new TypeMapRegistry();
             ConnectionMode = configuration.DbMode;
@@ -477,7 +478,7 @@ public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext
                 throw new ConnectionFailedException(ex.Message);
             }
 
-            _dataSourceInfo = DataSourceInformation.Create(conn);
+            _dataSourceInfo = DataSourceInformation.Create(conn, _loggerFactory);
             SetupConnectionSessionSettingsForProvider(conn);
             Name = _dataSourceInfo.DatabaseProductName;
             if (_dataSourceInfo.Product == SupportedDatabase.Sqlite)
@@ -505,7 +506,7 @@ public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext
             _isolationResolver ??= new IsolationResolver(Product, RCSIEnabled);
         }
         catch(Exception ex){
-            Console.WriteLine(ex.Message);
+            _logger.LogError(ex, ex.Message);
             throw;
         }
         finally

--- a/pengdows.crud/TypeCoercionHelper.cs
+++ b/pengdows.crud/TypeCoercionHelper.cs
@@ -2,6 +2,8 @@
 
 using System.Globalization;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using pengdows.crud.enums;
 
 #endregion
@@ -10,6 +12,13 @@ namespace pengdows.crud;
 
 public static class TypeCoercionHelper
 {
+    private static ILogger<TypeCoercionHelper> _logger = NullLogger<TypeCoercionHelper>.Instance;
+
+    public static ILogger<TypeCoercionHelper> Logger
+    {
+        get => _logger;
+        set => _logger = value ?? NullLogger<TypeCoercionHelper>.Instance;
+    }
     public static object? Coerce(
         object? value,
         Type dbFieldType,
@@ -34,7 +43,10 @@ public static class TypeCoercionHelper
                     throw new ArgumentException($"Cannot convert value '{value}' to enum {columnInfo.EnumType}.");
 
                 case EnumParseFailureMode.SetNullAndLog:
-                    Console.WriteLine($"Cannot convert '{value}' to non-nullable enum {columnInfo.EnumType}.");
+                    Logger.LogWarning(
+                        "Cannot convert '{Value}' to non-nullable enum {EnumType}.",
+                        value,
+                        columnInfo.EnumType);
                     return null;
                 // if (Nullable.GetUnderlyingType(targetType) == columnInfo.EnumType)
                 //     return null;


### PR DESCRIPTION
## Summary
- replace `Console.WriteLine` usages with `ILogger`
- add logger support to `DataSourceInformation` and `TypeCoercionHelper`
- wire up `DataSourceInformation` logger in `DatabaseContext`
- adjust tests for new logger parameters

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d36fd9cdc832596f3886f057528df