### PR TITLE
Add packaging for abstractions project

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,11 +84,14 @@ jobs:
       - name: Update version in .csproj
         run: |
           sed -i "s|<Version>.*</Version>|<Version>${{ steps.version.outputs.version }}</Version>|" pengdows.crud/pengdows.crud.csproj
+          sed -i "s|<Version>.*</Version>|<Version>${{ steps.version.outputs.version }}</Version>|" pengdows.crud.abstractions/pengdows.crud.abstractions.csproj
 
       - name: Build and pack
         run: |
           dotnet build pengdows.crud/pengdows.crud.csproj -c Release
           dotnet pack pengdows.crud/pengdows.crud.csproj -c Release --no-build
+          dotnet build pengdows.crud.abstractions/pengdows.crud.abstractions.csproj -c Release
+          dotnet pack pengdows.crud.abstractions/pengdows.crud.abstractions.csproj -c Release --no-build
 
       - name: Push package to NuGet
         run: |
@@ -96,12 +99,15 @@ jobs:
           dotnet nuget push pengdows.crud/bin/Release/pengdows.crud.${{ steps.version.outputs.version_short }}.nupkg \
             --source https://api.nuget.org/v3/index.json \
             --api-key ${{ secrets.NUGET_API_KEY }}
+          dotnet nuget push pengdows.crud.abstractions/bin/Release/pengdows.crud.abstractions.${{ steps.version.outputs.version_short }}.nupkg \
+            --source https://api.nuget.org/v3/index.json \
+            --api-key ${{ secrets.NUGET_API_KEY }}
 
       - name: Commit version bump
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pengdows.crud/pengdows.crud.csproj
+          git add pengdows.crud/pengdows.crud.csproj pengdows.crud.abstractions/pengdows.crud.abstractions.csproj
           git commit -m "Bump version to v${{ steps.version.outputs.version_short }}" || echo "No changes to commit"
 
       - name: Push version bump commit

--- a/README.md
+++ b/README.md
@@ -127,7 +127,10 @@ Topics include:
 
 ```bash
 dotnet add package pengdows.crud
+dotnet add package pengdows.crud.abstractions
 ```
+
+`pengdows.crud.abstractions` contains the shared interfaces used for dependency injection and unit testing.
 
 ```csharp
 using System.Data.SqlClient;

--- a/pengdows.crud.abstractions/pengdows.crud.abstractions.csproj
+++ b/pengdows.crud.abstractions/pengdows.crud.abstractions.csproj
@@ -5,12 +5,27 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>pengdows.crud</RootNamespace>
+        <PackageId>pengdows.crud.abstractions</PackageId>
+        <Version>1.0.0.0</Version>
+        <Description>Shared interfaces and abstractions for pengdows.crud</Description>
+        <Authors>Pengdows</Authors>
+        <PackageTags>crud,nuget</PackageTags>
+        <RepositoryUrl>https://github.com/pengdows/pengdows.crud</RepositoryUrl>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageProjectUrl>https://github.com/pengdows/pengdows.crud/wiki</PackageProjectUrl>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <RepositoryType>git</RepositoryType>
+        <WarningsAsErrors>true</WarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.5"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4"/>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.4"/>
+    </ItemGroup>
+    <ItemGroup>
+        <None Include="README.md" Pack="true" PackagePath="" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- generate a NuGet package for pengdows.crud.abstractions
- expose the abstractions package in the README
- ship both packages from the deploy workflow

## Testing
- `dotnet restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863093523848325be843bdf62d9ebbc