### PR TITLE
Enable NuGet packaging for abstractions project

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ Topics include:
 dotnet add package pengdows.crud
 ```
 
+If you only need the core interfaces for custom implementations, reference the
+`pengdows.crud.abstractions` package:
+
+```bash
+dotnet add package pengdows.crud.abstractions
+```
+
 ```csharp
 using System.Data.SqlClient;
 using pengdows.crud;

--- a/pengdows.crud.abstractions/README.md
+++ b/pengdows.crud.abstractions/README.md
@@ -1,0 +1,4 @@
+# pengdows.crud.abstractions
+
+This package contains the core interfaces and infrastructure contracts used by the `pengdows.crud` library.
+It allows other libraries or applications to reference the abstractions without depending on the full implementation.

--- a/pengdows.crud.abstractions/pengdows.crud.abstractions.csproj
+++ b/pengdows.crud.abstractions/pengdows.crud.abstractions.csproj
@@ -5,12 +5,28 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>pengdows.crud</RootNamespace>
+        <PackageId>pengdows.crud.abstractions</PackageId>
+        <Version>1.0.0.0</Version>
+        <Description>Interfaces and abstractions for the pengdows.crud library.</Description>
+        <Authors>Pengdows</Authors>
+        <PackageTags>crud,nuget</PackageTags>
+        <RepositoryUrl>https://github.com/pengdows/pengdows.crud</RepositoryUrl>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageProjectUrl>https://github.com/pengdows/pengdows.crud/wiki</PackageProjectUrl>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <RepositoryType>git</RepositoryType>
+        <WarningsAsErrors>true</WarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.5"/>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4"/>
         <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.4"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="README.md" Pack="true" PackagePath="" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add packaging metadata to `pengdows.crud.abstractions`
- include a README for the new package
- update top-level README with install instructions for the abstractions package

## Testing
- `dotnet pack pengdows.crud.abstractions/pengdows.crud.abstractions.csproj -c Release -o ./artifacts` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863bdd167dc8325a8d04651736e8aa8