### PR TITLE
Publish abstractions first

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,26 +86,26 @@ jobs:
 
       - name: Pack with custom version
         run: |
-          dotnet pack pengdows.crud/pengdows.crud.csproj -c Release \
-            --no-build \
-            -p:PackageVersion=${{ steps.version.outputs.version }}
           dotnet pack pengdows.crud.abstractions/pengdows.crud.abstractions.csproj -c Release \
             --no-build \
             -p:PackageVersion=${{ steps.version.outputs.version }}
           dotnet pack pengdows.crud.fakeDb/pengdows.crud.fakeDb.csproj -c Release \
             --no-build \
             -p:PackageVersion=${{ steps.version.outputs.version }}
+          dotnet pack pengdows.crud/pengdows.crud.csproj -c Release \
+            --no-build \
+            -p:PackageVersion=${{ steps.version.outputs.version }}
 
       - name: Push package to NuGet
         run: |
           set -euo pipefail
-          dotnet nuget push pengdows.crud/bin/Release/pengdows.crud.${{ steps.version.outputs.version_short }}.nupkg \
-            --source https://api.nuget.org/v3/index.json \
-            --api-key ${{ secrets.NUGET_API_KEY }}
           dotnet nuget push pengdows.crud.abstractions/bin/Release/pengdows.crud.abstractions.${{ steps.version.outputs.version_short }}.nupkg \
             --source https://api.nuget.org/v3/index.json \
             --api-key ${{ secrets.NUGET_API_KEY }}
           dotnet nuget push pengdows.crud.fakeDb/bin/Release/pengdows.crud.fakeDb.${{ steps.version.outputs.version_short }}.nupkg \
+            --source https://api.nuget.org/v3/index.json \
+            --api-key ${{ secrets.NUGET_API_KEY }}
+          dotnet nuget push pengdows.crud/bin/Release/pengdows.crud.${{ steps.version.outputs.version_short }}.nupkg \
             --source https://api.nuget.org/v3/index.json \
             --api-key ${{ secrets.NUGET_API_KEY }}
 

--- a/build.sh
+++ b/build.sh
@@ -16,12 +16,12 @@ update_version() {
   sed -i "s|<Version>.*</Version>|<Version>${VERSION}</Version>|" "$csproj"
 }
 
-update_version pengdows.crud/pengdows.crud.csproj
 update_version pengdows.crud.abstractions/pengdows.crud.abstractions.csproj
 update_version pengdows.crud.fakeDb/pengdows.crud.fakeDb.csproj
+update_version pengdows.crud/pengdows.crud.csproj
 
 # Build and pack each project
-for proj in pengdows.crud pengdows.crud.abstractions pengdows.crud.fakeDb; do
+for proj in pengdows.crud.abstractions pengdows.crud.fakeDb pengdows.crud; do
   dotnet pack "$proj/$proj.csproj" -c Release
   pkg="${proj}/bin/Release/${proj}.${VERSION_SHORT}.nupkg"
   dotnet nuget push "$pkg" --source https://api.nuget.org/v3/index.json --api-key "$API_KEY"


### PR DESCRIPTION
## Summary
- publish `pengdows.crud.abstractions` before its dependents

## Testing
- `dotnet test --no-build --configuration Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866888c40b483259a1a22214e844c75