### PR TITLE
Add list-based retrieve and delete methods

### DIFF
--- a/pengdows.crud.Tests/UpdateDeleteAsyncTests.cs
+++ b/pengdows.crud.Tests/UpdateDeleteAsyncTests.cs
@@ -49,6 +49,34 @@ public class UpdateDeleteAsyncTests : SqlLiteContextTestBase
         Assert.Equal(1, affected);
     }
 
+    [Fact]
+    public async Task RetrieveAsync_ReturnsRows()
+    {
+        await BuildTestTable();
+        var e1 = new TestEntity { Name = Guid.NewGuid().ToString() };
+        var e2 = new TestEntity { Name = Guid.NewGuid().ToString() };
+        await helper.CreateAsync(e1, Context);
+        await helper.CreateAsync(e2, Context);
+
+        var ids = (await helper.LoadListAsync(helper.BuildBaseRetrieve("a"))).Select(x => x.Id).ToList();
+        var result = await helper.RetrieveAsync(ids);
+        Assert.Equal(ids.Count, result.Count);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_List_RemovesRows()
+    {
+        await BuildTestTable();
+        var e1 = new TestEntity { Name = Guid.NewGuid().ToString() };
+        var e2 = new TestEntity { Name = Guid.NewGuid().ToString() };
+        await helper.CreateAsync(e1, Context);
+        await helper.CreateAsync(e2, Context);
+
+        var ids = (await helper.LoadListAsync(helper.BuildBaseRetrieve("a"))).Select(x => x.Id).ToList();
+        var affected = await helper.DeleteAsync(ids);
+        Assert.Equal(ids.Count, affected);
+    }
+
     private async Task BuildTestTable()
     {
         var qp = Context.QuotePrefix;

--- a/pengdows.crud.Tests/UpdateDeleteAsyncTests.cs
+++ b/pengdows.crud.Tests/UpdateDeleteAsyncTests.cs
@@ -77,6 +77,20 @@ public class UpdateDeleteAsyncTests : SqlLiteContextTestBase
         Assert.Equal(ids.Count, affected);
     }
 
+    [Fact]
+    public async Task RetrieveOneAsync_ById_ReturnsRow()
+    {
+        await BuildTestTable();
+        var entity = new TestEntity { Name = Guid.NewGuid().ToString() };
+        await helper.CreateAsync(entity, Context);
+
+        var loaded = (await helper.LoadListAsync(helper.BuildBaseRetrieve("a"))).First();
+        var result = await helper.RetrieveOneAsync(loaded.Id);
+
+        Assert.NotNull(result);
+        Assert.Equal(loaded.Id, result!.Id);
+    }
+
     private async Task BuildTestTable()
     {
         var qp = Context.QuotePrefix;

--- a/pengdows.crud.abstractions/IEntityHelper.cs
+++ b/pengdows.crud.abstractions/IEntityHelper.cs
@@ -116,6 +116,11 @@ public interface IEntityHelper<TEntity, TRowID> where TEntity : class, new()
     Task<TEntity?> RetrieveOneAsync(TEntity objectToRetrieve, IDatabaseContext? context = null);
 
     /// <summary>
+    /// Loads a single object from the database using the row ID.
+    /// </summary>
+    Task<TEntity?> RetrieveOneAsync(TRowID id, IDatabaseContext? context = null);
+
+    /// <summary>
     /// Loads a single object using a custom SQL container.
     /// </summary>
     Task<TEntity?> LoadSingleAsync(ISqlContainer sc);

--- a/pengdows.crud.abstractions/IEntityHelper.cs
+++ b/pengdows.crud.abstractions/IEntityHelper.cs
@@ -84,6 +84,16 @@ public interface IEntityHelper<TEntity, TRowID> where TEntity : class, new()
     Task<int> DeleteAsync(TRowID id, IDatabaseContext? context = null);
 
     /// <summary>
+    /// Loads all entities matching the provided IDs.
+    /// </summary>
+    Task<List<TEntity>> RetrieveAsync(IEnumerable<TRowID> ids, IDatabaseContext? context = null);
+
+    /// <summary>
+    /// Executes a DELETE for all provided IDs and returns the number of affected rows.
+    /// </summary>
+    Task<int> DeleteAsync(IEnumerable<TRowID> ids, IDatabaseContext? context = null);
+
+    /// <summary>
     /// Executes an UPDATE for the given object and returns the number of affected rows.
     /// Returns 0 when no changes are detected.
     /// </summary>

--- a/pengdows.crud/EntityHelper.cs
+++ b/pengdows.crud/EntityHelper.cs
@@ -240,6 +240,32 @@ public class EntityHelper<TEntity, TRowID> :
         return await sc.ExecuteNonQueryAsync();
     }
 
+    public async Task<List<TEntity>> RetrieveAsync(IEnumerable<TRowID> ids, IDatabaseContext? context = null)
+    {
+        if (ids == null) throw new ArgumentNullException(nameof(ids));
+
+        var list = ids.Distinct().ToList();
+        if (list.Count == 0) return new List<TEntity>();
+
+        var ctx = context ?? _context;
+        var sc = BuildRetrieve(list, ctx);
+        return await LoadListAsync(sc);
+    }
+
+    public async Task<int> DeleteAsync(IEnumerable<TRowID> ids, IDatabaseContext? context = null)
+    {
+        if (ids == null) throw new ArgumentNullException(nameof(ids));
+
+        var list = ids.Distinct().ToList();
+        if (list.Count == 0) return 0;
+
+        var ctx = context ?? _context;
+        var sc = ctx.CreateSqlContainer();
+        sc.Query.Append("DELETE FROM ").Append(WrappedTableName);
+        BuildWhere(WrapObjectName(_idColumn!.Name), list, sc);
+        return await sc.ExecuteNonQueryAsync();
+    }
+
 
     public Action<object, object?> GetOrCreateSetter(PropertyInfo prop)
     {

--- a/pengdows.crud/EntityHelper.cs
+++ b/pengdows.crud/EntityHelper.cs
@@ -295,6 +295,14 @@ public class EntityHelper<TEntity, TRowID> :
         return LoadSingleAsync(sc);
     }
 
+    public Task<TEntity?> RetrieveOneAsync(TRowID id, IDatabaseContext? context = null)
+    {
+        var ctx = context ?? _context;
+        var list = new List<TRowID> { id };
+        var sc = BuildRetrieve(list, ctx);
+        return LoadSingleAsync(sc);
+    }
+
     public async Task<TEntity?> LoadSingleAsync(ISqlContainer sc)
     {
         await using var reader = await sc.ExecuteReaderAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- add RetrieveAsync and DeleteAsync overloads for enumerable row ids
- expose the new methods on `IEntityHelper`
- test batch retrieval and deletion

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686afab598ec8325ad24d4cc615846fa