### PR TITLE
Add additional TrackedReader tests

### DIFF
--- a/pengdows.crud.Tests/wrappers/TrackedReaderTest.cs
+++ b/pengdows.crud.Tests/wrappers/TrackedReaderTest.cs
@@ -107,4 +107,63 @@ public class TrackedReaderTests
         Assert.Equal("value", tracked[0]);
         Assert.Equal("value2", tracked["col"]);
     }
-}
+
+    [Fact]
+    public void Read_DoesNotClose_WhenShouldCloseConnectionFalse()
+    {
+        var reader = new Mock<DbDataReader>();
+        reader.Setup(r => r.Read()).Returns(false);
+
+        var connection = new Mock<ITrackedConnection>();
+        var locker = new Mock<IAsyncDisposable>();
+        locker.Setup(l => l.DisposeAsync()).Returns(ValueTask.CompletedTask);
+
+        var tracked = new TrackedReader(reader.Object, connection.Object, locker.Object, false);
+
+        var result = tracked.Read();
+
+        Assert.False(result);
+        connection.Verify(c => c.Close(), Times.Never);
+        locker.Verify(l => l.DisposeAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task ReadAsync_DisposesAfterLastRow()
+    {
+        var reader = new Mock<FakeDbDataReader>();
+        reader.SetupSequence(r => r.ReadAsync(CancellationToken.None))
+            .ReturnsAsync(true)
+            .ReturnsAsync(false);
+
+        reader.Setup(r => r.DisposeAsync()).Returns(ValueTask.CompletedTask);
+
+        var connection = new Mock<ITrackedConnection>();
+        var locker = new Mock<IAsyncDisposable>();
+        locker.Setup(l => l.DisposeAsync()).Returns(ValueTask.CompletedTask);
+
+        var tracked = new TrackedReader(reader.Object, connection.Object, locker.Object, true);
+
+        var first = await tracked.ReadAsync();
+        Assert.True(first);
+        connection.Verify(c => c.Close(), Times.Never);
+        locker.Verify(l => l.DisposeAsync(), Times.Never);
+
+        var second = await tracked.ReadAsync();
+        Assert.False(second);
+        connection.Verify(c => c.Close(), Times.Once);
+        locker.Verify(l => l.DisposeAsync(), Times.Once);
+    }
+
+    [Fact]
+    public void NextResult_ReturnsFalseWithoutCallingReader()
+    {
+        var reader = new Mock<DbDataReader>();
+        reader.Setup(r => r.NextResult()).Throws<InvalidOperationException>();
+
+        var tracked = new TrackedReader(reader.Object, Mock.Of<ITrackedConnection>(), Mock.Of<IAsyncDisposable>(), false);
+
+        var result = tracked.NextResult();
+
+        Assert.False(result);
+        reader.Verify(r => r.NextResult(), Times.Never);
+    }}


### PR DESCRIPTION
## Summary
- extend tests for TrackedReader
  - verify connection isn't closed when `shouldCloseConnection` is false
  - check disposal occurs after the last row is read
  - ensure `NextResult` always returns `false`

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d6e2321b483259a3ee60d491e3ccf