### PR TITLE
Fix UpsertAsync original retrieval via ID

### DIFF
--- a/pengdows.crud/EntityHelper.cs
+++ b/pengdows.crud/EntityHelper.cs
@@ -554,7 +554,11 @@ public class EntityHelper<TEntity, TRowID> :
 
     private async Task<TEntity?> LoadOriginalAsync(TEntity objectToUpdate)
     {
-        return await RetrieveOneAsync(objectToUpdate);
+        var idValue = _idColumn!.PropertyInfo.GetValue(objectToUpdate);
+        if (IsDefaultId(idValue))
+            return null;
+
+        return await RetrieveOneAsync((TRowID)idValue!);
     }
 
     private (StringBuilder clause, List<DbParameter> parameters) BuildSetClause(TEntity updated, TEntity? original, IDatabaseContext context)


### PR DESCRIPTION
## Summary
- ensure `UpsertAsync` fetches the original entity based on the ID when computing updates

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d9219f8f48325aca6c12107648524