### PR TITLE
Refactor TrackedConnection lock creation

### DIFF
--- a/pengdows.crud.Tests/CompareResultsTests.cs
+++ b/pengdows.crud.Tests/CompareResultsTests.cs
@@ -1,0 +1,80 @@
+#region
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using pengdows.crud;
+using pengdows.crud.configuration;
+using pengdows.crud.enums;
+using pengdows.crud.FakeDb;
+using Xunit;
+
+#endregion
+
+namespace pengdows.crud.Tests;
+
+public class CompareResultsTests
+{
+    private static StringBuilder Invoke(DatabaseContext ctx, Dictionary<string, string> expected, Dictionary<string, string> recorded)
+    {
+        var mi = typeof(DatabaseContext).GetMethod("CompareResults", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        return (StringBuilder)mi.Invoke(ctx, new object[] { expected, recorded })!;
+    }
+
+    private static DatabaseContext CreateContext()
+    {
+        var config = new DatabaseContextConfiguration
+        {
+            ConnectionString = $"Data Source=:memory:;EmulatedProduct={SupportedDatabase.SqlServer}",
+            ProviderName = SupportedDatabase.SqlServer.ToString(),
+            DbMode = DbMode.SingleConnection
+        };
+        var factory = new FakeDbFactory(SupportedDatabase.SqlServer);
+        return new DatabaseContext(config, factory);
+    }
+
+    [Fact]
+    public void CompareResults_NoDifferences_ReturnsEmpty()
+    {
+        using var ctx = CreateContext();
+        var expected = new Dictionary<string, string> { { "ANSI_NULLS", "ON" } };
+        var recorded = new Dictionary<string, string> { { "ANSI_NULLS", "ON" } };
+
+        var sb = Invoke(ctx, expected, recorded);
+
+        Assert.Equal(string.Empty, sb.ToString());
+    }
+
+    [Fact]
+    public void CompareResults_SingleDifference_ReturnsSetStatement()
+    {
+        using var ctx = CreateContext();
+        var expected = new Dictionary<string, string> { { "ANSI_NULLS", "ON" } };
+        var recorded = new Dictionary<string, string> { { "ANSI_NULLS", "OFF" } };
+
+        var sb = Invoke(ctx, expected, recorded);
+
+        Assert.Equal("SET ANSI_NULLS ON", sb.ToString());
+    }
+
+    [Fact]
+    public void CompareResults_MultipleDifferences_JoinWithNewLines()
+    {
+        using var ctx = CreateContext();
+        var expected = new Dictionary<string, string>
+        {
+            { "ANSI_NULLS", "ON" },
+            { "ANSI_PADDING", "ON" }
+        };
+        var recorded = new Dictionary<string, string>
+        {
+            { "ANSI_NULLS", "OFF" },
+            { "ANSI_PADDING", "OFF" }
+        };
+
+        var sb = Invoke(ctx, expected, recorded);
+
+        var expectedText = $"SET ANSI_NULLS ON{Environment.NewLine}SET ANSI_PADDING ON";
+        Assert.Equal(expectedText, sb.ToString());
+    }
+}

--- a/pengdows.crud.Tests/wrappers/TrackedConnectionTests.cs
+++ b/pengdows.crud.Tests/wrappers/TrackedConnectionTests.cs
@@ -1,0 +1,68 @@
+#region
+using System.Threading.Tasks;
+using pengdows.crud.FakeDb;
+using pengdows.crud.threading;
+using pengdows.crud.wrappers;
+using Xunit;
+
+#endregion
+
+namespace pengdows.crud.Tests.wrappers;
+
+public class TrackedConnectionTests
+{
+    [Fact]
+    public void GetLock_NoSharedConnection_ReturnsNoOpInstance()
+    {
+        using var conn = new FakeDbConnection();
+        using var tracked = new TrackedConnection(conn);
+
+        var locker1 = tracked.GetLock();
+        var locker2 = tracked.GetLock();
+
+        Assert.Same(NoOpAsyncLocker.Instance, locker1);
+        Assert.Same(locker1, locker2);
+    }
+
+    [Fact]
+    public async Task GetLock_SharedConnection_ReturnsRealAsyncLocker()
+    {
+        using var conn = new FakeDbConnection();
+        using var tracked = new TrackedConnection(conn, isSharedConnection: true);
+
+        await using var locker = tracked.GetLock();
+
+        Assert.IsType<RealAsyncLocker>(locker);
+        await locker.LockAsync();
+        await locker.DisposeAsync();
+    }
+
+    [Fact]
+    public void GetLock_SharedConnection_ReturnsNewInstanceEachTime()
+    {
+        using var conn = new FakeDbConnection();
+        using var tracked = new TrackedConnection(conn, isSharedConnection: true);
+
+        var first = tracked.GetLock();
+        var second = tracked.GetLock();
+
+        Assert.IsType<RealAsyncLocker>(first);
+        Assert.IsType<RealAsyncLocker>(second);
+        Assert.NotSame(first, second);
+    }
+
+    [Fact]
+    public void Open_InvokesOnFirstOpen_OnlyOnce()
+    {
+        using var conn = new FakeDbConnection();
+        var count = 0;
+        using var tracked = new TrackedConnection(conn, onFirstOpen: _ => count++);
+
+        tracked.Open();
+        tracked.Close();
+        tracked.Open();
+
+        Assert.Equal(1, count);
+        Assert.True(tracked.WasOpened);
+    }
+}


### PR DESCRIPTION
## Summary
- reduce cyclomatic complexity of `TrackedConnection.GetLock`
- add new tests for `TrackedConnection`
- cover `DatabaseContext.CompareResults` via reflection tests

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d9aac86dc832596dcdce8dc89362c