### PR TITLE
Add DbProviderLoader provider name validation

### DIFF
--- a/pengdows.crud.Tests/configuration/DbProviderLoaderTest.cs
+++ b/pengdows.crud.Tests/configuration/DbProviderLoaderTest.cs
@@ -134,8 +134,8 @@ public class DbProviderLoaderTests
         var loader = new DbProviderLoader(config, logger.Object);
         var services = new ServiceCollection();
 
-        // Ensure the assembly is loaded so the provider self-registers
-        _ = SqliteFactory.Instance;
+        // Register the provider with DbProviderFactories so fallback succeeds
+        DbProviderFactories.RegisterFactory("Microsoft.Data.Sqlite", SqliteFactory.Instance);
 
         loader.LoadAndRegisterProviders(services);
 

--- a/pengdows.crud.Tests/configuration/DbProviderLoaderTest.cs
+++ b/pengdows.crud.Tests/configuration/DbProviderLoaderTest.cs
@@ -3,6 +3,8 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.IO;
+using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -88,6 +90,93 @@ public class DbProviderLoaderTests
 
         var logger = new Mock<ILogger<DbProviderLoader>>();
         var loader = new DbProviderLoader(config, logger.Object);
+
+        Assert.Throws<InvalidOperationException>(() => loader.LoadAndRegisterProviders(new ServiceCollection()));
+    }
+
+    [Fact]
+    public void LoadAndRegisterProviders_RegistersUsingAssemblyPath()
+    {
+        var assemblyPath = Path.GetFileName(typeof(PropertyFactory).Assembly.Location);
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["DatabaseProviders:path:ProviderName"] = "Test.PathProvider",
+                ["DatabaseProviders:path:FactoryType"] = typeof(PropertyFactory).FullName,
+                ["DatabaseProviders:path:AssemblyPath"] = assemblyPath
+            })
+            .Build();
+
+        var logger = new Mock<ILogger<DbProviderLoader>>();
+        var loader = new DbProviderLoader(config, logger.Object);
+        var services = new ServiceCollection();
+
+        loader.LoadAndRegisterProviders(services);
+
+        var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredKeyedService<DbProviderFactory>("path");
+
+        Assert.Same(PropertyFactory.Instance, factory);
+        Assert.Same(PropertyFactory.Instance, DbProviderFactories.GetFactory("Test.PathProvider"));
+    }
+
+    [Fact]
+    public void LoadAndRegisterProviders_FallbackToDbProviderFactories()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["DatabaseProviders:sqlite:ProviderName"] = "Microsoft.Data.Sqlite"
+            })
+            .Build();
+
+        var logger = new Mock<ILogger<DbProviderLoader>>();
+        var loader = new DbProviderLoader(config, logger.Object);
+        var services = new ServiceCollection();
+
+        // Ensure the assembly is loaded so the provider self-registers
+        _ = SqliteFactory.Instance;
+
+        loader.LoadAndRegisterProviders(services);
+
+        var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredKeyedService<DbProviderFactory>("sqlite");
+
+        Assert.Same(SqliteFactory.Instance, factory);
+        Assert.Same(SqliteFactory.Instance, DbProviderFactories.GetFactory("Microsoft.Data.Sqlite"));
+    }
+
+    [Fact]
+    public void LoadAndRegisterProviders_InvalidProviderName_Throws()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["DatabaseProviders:invalid:ProviderName"] = "Unknown.Provider"
+            })
+            .Build();
+
+        var logger = new Mock<ILogger<DbProviderLoader>>();
+        var loader = new DbProviderLoader(config, logger.Object);
+
+        Assert.Throws<InvalidOperationException>(() => loader.LoadAndRegisterProviders(new ServiceCollection()));
+    }
+
+    [Fact]
+    public void LoadAndRegisterProviders_MissingProviderName_Throws()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["DatabaseProviders:missing:AssemblyName"] = "Microsoft.Data.Sqlite"
+            })
+            .Build();
+
+        var logger = new Mock<ILogger<DbProviderLoader>>();
+        var loader = new DbProviderLoader(config, logger.Object);
+
+        // ensure assembly load doesn't hide missing provider
+        _ = SqliteFactory.Instance;
 
         Assert.Throws<InvalidOperationException>(() => loader.LoadAndRegisterProviders(new ServiceCollection()));
     }

--- a/pengdows.crud/configuration/DbProviderLoader.cs
+++ b/pengdows.crud/configuration/DbProviderLoader.cs
@@ -32,7 +32,7 @@ public class DbProviderLoader : IDbProviderLoader
         {
             var providerKey = kvp.Key;
 
-            if (string.IsNullOrEmpty(providerKey))
+            if (string.IsNullOrEmpty(kvp.Value.ProviderName))
                 throw new InvalidOperationException($"ProviderName is missing for provider '{providerKey}'.");
 
             _logger.LogInformation("Loading DbProviderFactory for provider '{ProviderKey}'", providerKey);


### PR DESCRIPTION
## Summary
- add unit tests covering SQLite fallback and assembly path load
- validate that each provider has a ProviderName configured

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68711bc8340c832584fb1111df9f8f9d