### PR TITLE
Improve FakeDb for custom results

### DIFF
--- a/pengdows.crud.fakeDb/FakeDbCommand.cs
+++ b/pengdows.crud.fakeDb/FakeDbCommand.cs
@@ -41,18 +41,29 @@ public sealed class FakeDbCommand : DbCommand
     {
     }
 
+    private FakeDbConnection? FakeConnection => Connection as FakeDbConnection;
+
     public override int ExecuteNonQuery()
     {
+        var conn = FakeConnection;
+        if (conn != null && conn.NonQueryResults.Count > 0)
+            return conn.NonQueryResults.Dequeue();
         return 1;
     }
 
     public override object ExecuteScalar()
     {
+        var conn = FakeConnection;
+        if (conn != null && conn.ScalarResults.Count > 0)
+            return conn.ScalarResults.Dequeue();
         return 42;
     }
 
     protected override DbDataReader ExecuteDbDataReader(CommandBehavior _)
     {
+        var conn = FakeConnection;
+        if (conn != null && conn.ReaderResults.Count > 0)
+            return new FakeDbDataReader(conn.ReaderResults.Dequeue());
         return new FakeDbDataReader();
     }
 

--- a/pengdows.crud.fakeDb/FakeDbConnection.cs
+++ b/pengdows.crud.fakeDb/FakeDbConnection.cs
@@ -1,5 +1,6 @@
 #region
 
+using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using pengdows.crud.enums;
@@ -16,6 +17,25 @@ public class FakeDbConnection : DbConnection, IDbConnection, IDisposable, IAsync
     private ConnectionState _state = ConnectionState.Closed;
     public override string DataSource => "FakeSource";
     public override string ServerVersion => "1.0";
+
+    internal readonly Queue<IEnumerable<Dictionary<string, object>>> ReaderResults = new();
+    internal readonly Queue<object?> ScalarResults = new();
+    internal readonly Queue<int> NonQueryResults = new();
+
+    public void EnqueueReaderResult(IEnumerable<Dictionary<string, object>> rows)
+    {
+        ReaderResults.Enqueue(rows);
+    }
+
+    public void EnqueueScalarResult(object? value)
+    {
+        ScalarResults.Enqueue(value);
+    }
+
+    public void EnqueueNonQueryResult(int value)
+    {
+        NonQueryResults.Enqueue(value);
+    }
 
     public SupportedDatabase EmulatedProduct
     {

--- a/pengdows.crud.fakeDb/README.md
+++ b/pengdows.crud.fakeDb/README.md
@@ -32,3 +32,20 @@ using var reader = await command.ExecuteReaderAsync();
 This makes `pengdows.crud.fakeDb` handy for testing any code that relies on
 `DbConnection` or `DbDataReader` without spinning up a real database.
 
+### Preloading Results
+
+`FakeDbConnection` can queue up results that will be returned the next time a
+command is executed. This allows tests to simulate query responses:
+
+```csharp
+var conn = new FakeDbConnection("Data Source=:memory:;EmulatedProduct=Sqlite");
+conn.EnqueueScalarResult(5);
+conn.EnqueueReaderResult(new[] { new Dictionary<string, object>{{"Name", "Jane"}} });
+conn.Open();
+using var cmd = conn.CreateCommand();
+var value = (int)cmd.ExecuteScalar(); // returns 5
+using var reader = cmd.ExecuteReader();
+reader.Read();
+var name = reader.GetString(0); // "Jane"
+```
+


### PR DESCRIPTION
## Summary
- extend FakeDb connection/command to allow queuing results
- document preloading fake results

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873b54360488325be4afec4b82ebc3a