### PR TITLE
Fix DataSourceInformationTests without Moq

### DIFF
--- a/pengdows.crud.Tests/DataSourceInformationTests.cs
+++ b/pengdows.crud.Tests/DataSourceInformationTests.cs
@@ -9,7 +9,6 @@ using System.Reflection;
 using System.Threading;
 using pengdows.crud.enums;
 using pengdows.crud.FakeDb;
-using Moq;
 using Microsoft.Extensions.Logging.Abstractions;
 using pengdows.crud.wrappers;
 using Xunit;
@@ -166,26 +165,18 @@ public class DataSourceInformationTests
     }
     private static ITrackedConnection BuildSqliteConnectionMock()
     {
-        var reader = new Mock<DbDataReader>();
-        reader.Setup(r => r.Read()).Returns(true);
-        reader.Setup(r => r.ReadAsync(It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        var factory = new FakeDbFactory(SupportedDatabase.Sqlite);
+        var conn = (FakeDbConnection)factory.CreateConnection();
+        conn.ConnectionString = $"Data Source=test;EmulatedProduct={SupportedDatabase.Sqlite}";
 
-        var command = new Mock<DbCommand>();
-        command.SetupProperty(c => c.CommandText);
-        command.Setup(c => c.ExecuteReader(It.IsAny<CommandBehavior>())).Returns(reader.Object);
-        command.Setup(c => c.ExecuteReaderAsync(It.IsAny<CommandBehavior>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(reader.Object);
-        command.Setup(c => c.ExecuteScalar()).Returns("3.0");
-        command.Setup(c => c.ExecuteScalarAsync(It.IsAny<CancellationToken>())).ReturnsAsync("3.0");
+        var row = new Dictionary<string, object> { { "version", "3.0" } };
+        // One result for IsSqliteAsync, one for GetVersionAsync, and one for IsSqliteSync
+        conn.EnqueueReaderResult(new[] { row });
+        conn.EnqueueReaderResult(new[] { row });
+        conn.EnqueueReaderResult(new[] { row });
 
-        var conn = new Mock<ITrackedConnection>();
-        conn.SetupAllProperties();
-        conn.Setup(c => c.CreateCommand()).Returns(command.Object);
-        conn.Setup(c => c.GetSchema(DbMetaDataCollectionNames.DataSourceInformation))
-            .Returns(new DataTable());
-
-        conn.Object.ConnectionString = $"Data Source=test;EmulatedProduct={SupportedDatabase.Sqlite}";
-        return conn.Object;
+        conn.Open();
+        return new TrackedConnection(conn);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- remove direct FakeDbConnection subclass in Sqlite schema test
- build Sqlite connections using FakeDbFactory

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873bbdf48348325983837d78bd05d62