### PR TITLE
Add coverage for async DataSourceInformation and TrackedReader

### DIFF
--- a/pengdows.crud.Tests/DataSourceInformationAsyncTests.cs
+++ b/pengdows.crud.Tests/DataSourceInformationAsyncTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using pengdows.crud;
+using pengdows.crud.FakeDb;
+using pengdows.crud.wrappers;
+using Xunit;
+
+namespace pengdows.crud.Tests;
+
+public class DataSourceInformationAsyncTests
+{
+    private static async Task<bool> InvokeIsSqliteAsync(ITrackedConnection conn)
+    {
+        var method = typeof(DataSourceInformation).GetMethod("IsSqliteAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var task = (Task<bool>)method.Invoke(null, new object?[] { conn, NullLogger<DataSourceInformation>.Instance })!;
+        return await task.ConfigureAwait(false);
+    }
+
+    private static async Task<string> InvokeGetVersionAsync(ITrackedConnection conn, string sql)
+    {
+        var method = typeof(DataSourceInformation).GetMethod("GetVersionAsync", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var task = (Task<string>)method.Invoke(null, new object?[] { conn, sql, NullLogger<DataSourceInformation>.Instance })!;
+        return await task.ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task IsSqliteAsync_ReturnsTrue_WhenVersionQuerySucceeds()
+    {
+        var conn = new FakeDbConnection();
+        conn.ConnectionString = $"Data Source=test;EmulatedProduct={SupportedDatabase.Sqlite}";
+        conn.EnqueueReaderResult(new[] { new Dictionary<string, object> { { "version", "3.0" } } });
+        using var tracked = new TrackedConnection(conn);
+
+        var result = await InvokeIsSqliteAsync(tracked);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task IsSqliteAsync_ReturnsFalse_WhenCommandFails()
+    {
+        var command = new Mock<DbCommand>();
+        command.Setup(c => c.ExecuteReaderAsync(It.IsAny<CommandBehavior>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException());
+        command.Setup(c => c.DisposeAsync()).Returns(ValueTask.CompletedTask);
+
+        var conn = new Mock<ITrackedConnection>();
+        conn.Setup(c => c.CreateCommand()).Returns(command.Object);
+
+        var result = await InvokeIsSqliteAsync(conn.Object);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task GetVersionAsync_ReturnsValue()
+    {
+        var conn = new FakeDbConnection();
+        conn.ConnectionString = $"Data Source=test;EmulatedProduct={SupportedDatabase.Sqlite}";
+        conn.EnqueueReaderResult(new[] { new Dictionary<string, object> { { "version", "9.9" } } });
+        using var tracked = new TrackedConnection(conn);
+
+        var result = await InvokeGetVersionAsync(tracked, "SELECT sqlite_version()");
+
+        Assert.Equal("9.9", result);
+    }
+}

--- a/pengdows.crud.Tests/SqlContainerMakeParameterNameTests.cs
+++ b/pengdows.crud.Tests/SqlContainerMakeParameterNameTests.cs
@@ -1,0 +1,24 @@
+using System.Data;
+using Moq;
+using pengdows.crud;
+using pengdows.crud.FakeDb;
+using Xunit;
+
+namespace pengdows.crud.Tests;
+
+public class SqlContainerMakeParameterNameTests
+{
+    [Fact]
+    public void MakeParameterName_DelegatesToContext()
+    {
+        var context = new Mock<IDatabaseContext>();
+        context.Setup(c => c.MakeParameterName(It.IsAny<DbParameter>())).Returns("@p0");
+        var container = new SqlContainer(context.Object);
+        var param = new FakeDbParameter { DbType = DbType.Int32, ParameterName = "p" };
+
+        var result = container.MakeParameterName(param);
+
+        Assert.Equal("@p0", result);
+        context.Verify(c => c.MakeParameterName(param), Times.Once);
+    }
+}

--- a/pengdows.crud.Tests/wrappers/TrackedReaderAdditionalTests.cs
+++ b/pengdows.crud.Tests/wrappers/TrackedReaderAdditionalTests.cs
@@ -1,0 +1,44 @@
+using System.Data;
+using System.Data.Common;
+using System.Threading.Tasks;
+using Moq;
+using pengdows.crud.wrappers;
+using Xunit;
+
+namespace pengdows.crud.Tests.wrappers;
+
+public class TrackedReaderAdditionalTests
+{
+    [Fact]
+    public void DelegatedMethods_ForwardToUnderlyingReader()
+    {
+        var reader = new Mock<DbDataReader>();
+        var bytes = new byte[4];
+        var chars = new char[3];
+        var dataReader = new Mock<IDataReader>().Object;
+        reader.Setup(r => r.GetBytes(1, 2, bytes, 3, 4)).Returns(7);
+        reader.Setup(r => r.GetChars(1, 2, chars, 3, 4)).Returns(8);
+        reader.Setup(r => r.GetData(1)).Returns(dataReader);
+        reader.Setup(r => r.GetDataTypeName(1)).Returns("varchar");
+        reader.Setup(r => r.GetValues(It.IsAny<object[]>())).Returns(5);
+
+        var tracked = new TrackedReader(reader.Object, Mock.Of<ITrackedConnection>(), Mock.Of<IAsyncDisposable>(), false);
+
+        Assert.Equal(7, tracked.GetBytes(1, 2, bytes, 3, 4));
+        Assert.Equal(8, tracked.GetChars(1, 2, chars, 3, 4));
+        Assert.Same(dataReader, tracked.GetData(1));
+        Assert.Equal("varchar", tracked.GetDataTypeName(1));
+        Assert.Equal(5, tracked.GetValues(new object[2]));
+    }
+
+    [Fact]
+    public void Close_CallsUnderlyingReader()
+    {
+        var reader = new Mock<DbDataReader>();
+        var tracked = new TrackedReader(reader.Object, Mock.Of<ITrackedConnection>(), Mock.Of<IAsyncDisposable>(), false);
+
+        tracked.Close();
+
+        reader.Verify(r => r.Close(), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary
- add async tests for `DataSourceInformation`
- cover additional `TrackedReader` delegation methods
- test `SqlContainer.MakeParameterName` delegation

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873d52f888c83259ca09c75b441297f