### PR TITLE
Add Codecov integration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,8 @@ jobs:
           dotnet test --no-build --configuration Release \
             --collect:"XPlat Code Coverage" \
             --results-directory ./TestResults \
-            -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Include="[pengdows.crud]*"
+            -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Include="[pengdows.crud]*" \
+            -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Exclude="[pengdows.crud.Tests]*;[pengdows.crud.abstractions]*;[pengdows.crud.fakeDb]*;[testbed]*"
 
       - name: Generate coverage report
         run: |
@@ -90,6 +91,12 @@ jobs:
           else
             echo "✅ Visual code coverage $coverage_percent% meets threshold"
           fi
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: TestResults/**/coverage.cobertura.xml
+          fail_ci_if_error: true
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ riderModule.iml
 *.userosscache
 *.sln.docstates
 *.snk
+
+# Coverage
+TestResults/
+coverage-report/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![NuGet](https://img.shields.io/nuget/v/pengdows.crud.svg)](https://www.nuget.org/packages/pengdows.threading)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Build](https://github.com/pengdows/pengdows.crud/actions/workflows/deploy.yml/badge.svg)](https://github.com/pengdows/pengdows.crud/actions)
-[![Coverage](https://img.shields.io/badge/coverage-unknown-lightgrey.svg)](https://github.com/pengdows/pengdows.crud/actions)
+[![Coverage](https://codecov.io/gh/pengdows/pengdows.crud/branch/main/graph/badge.svg)](https://codecov.io/gh/pengdows/pengdows.crud)
 
 **pengdows.crud** is a SQL-first, strongly-typed, testable data access layer for .NET. It’s built for developers who want **full control** over SQL, **predictable behavior** across databases, and **no ORM magic**.
 


### PR DESCRIPTION
## Summary
- upload Cobertura coverage to Codecov in CI
- show real coverage badge from Codecov in README
- ignore coverage artifacts
- filter coverage so only the pengdows.crud assembly is measured

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874fbbc0c908325b7ceac7c908da9d7