### PR TITLE
Fix Codecov rate limit by adding token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,6 +97,7 @@ jobs:
         with:
           files: TestResults/**/coverage.cobertura.xml
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- add CODECOV_TOKEN secret usage in workflow to avoid rate limits

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687505853990832590b849a0ae0b90d8