### PR TITLE
Add AuditValueResolver tests

### DIFF
--- a/pengdows.crud.Tests/AuditValueResolverTests.cs
+++ b/pengdows.crud.Tests/AuditValueResolverTests.cs
@@ -1,0 +1,37 @@
+#region
+
+using System;
+using Xunit;
+
+#endregion
+
+namespace pengdows.crud.Tests;
+
+public class AuditValueResolverTests
+{
+    private class TestResolver : AuditValueResolver
+    {
+        private readonly IAuditValues _values;
+        public TestResolver(IAuditValues values) => _values = values;
+        public override IAuditValues Resolve() => _values;
+    }
+
+    [Fact]
+    public void AuditValueResolver_IsAbstract()
+    {
+        Assert.True(typeof(AuditValueResolver).IsAbstract);
+        Assert.True(typeof(IAuditValueResolver).IsAssignableFrom(typeof(AuditValueResolver)));
+    }
+
+    [Fact]
+    public void Resolve_ReturnsExpectedValues()
+    {
+        var expected = new AuditValues { UserId = "u" };
+        var resolver = new TestResolver(expected);
+
+        var result = resolver.Resolve();
+
+        Assert.Same(expected, result);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add basic tests for `AuditValueResolver`

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687632c2380c8325bca6098b3f413e8a