### PR TITLE
Enable MERGE for PostgreSQL 15+

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@
 - Connection lifecycle modes: `New`, `Shared`, `KeepAlive`.
 - **Scoped transactions** via `TransactionContext`.
 - Works cleanly with DI and ADO.NET—**no leaky abstractions**.
+- Automatic database version detection for feature gating.
+- MERGE statements supported on SQL Server, Oracle, Firebird, and PostgreSQL 15+.
 
 ---
 

--- a/pengdows.crud.Tests/DataSourceInformationTests.cs
+++ b/pengdows.crud.Tests/DataSourceInformationTests.cs
@@ -49,9 +49,15 @@ public static class DataSourceTestData
                 _ => string.Empty
             };
 
+            var versionString = db switch
+            {
+                SupportedDatabase.PostgreSql => "PostgreSQL 15.0",
+                _ => $"{db} v1.2.3"
+            };
+
             var scalars = new Dictionary<string, object>
             {
-                [versionSql] = $"{db} v1.2.3"
+                [versionSql] = versionString
             };
 
             yield return new object[] { db, schema, scalars };
@@ -91,10 +97,15 @@ public class DataSourceInformationTests
         };
         Assert.Equal(expectedMarker, info.ParameterMarker);
 
+        // Assert: major version parsing
+        var expectedMajor = db == SupportedDatabase.PostgreSql ? 15 : 1;
+        Assert.Equal(expectedMajor, info.GetMajorVersion());
+
         // Assert: merge support
         var canMerge = db == SupportedDatabase.SqlServer
                        || db == SupportedDatabase.Oracle
-                       || db == SupportedDatabase.Firebird;
+                       || db == SupportedDatabase.Firebird
+                       || (db == SupportedDatabase.PostgreSql && info.GetMajorVersion() > 14);
         Assert.Equal(canMerge, info.SupportsMerge);
 
         // Assert: insert-on-conflict support

--- a/pengdows.crud/DataSourceInformation.cs
+++ b/pengdows.crud/DataSourceInformation.cs
@@ -142,6 +142,7 @@ public class DataSourceInformation : IDataSourceInformation
         SupportedDatabase.SqlServer => true,
         SupportedDatabase.Oracle => true,
         SupportedDatabase.Firebird => true,
+        SupportedDatabase.PostgreSql => GetMajorVersion() > 14,
         _ => false
     };
 
@@ -380,5 +381,29 @@ public class DataSourceInformation : IDataSourceInformation
         {
             return defaultValue;
         }
+    }
+
+    public int? GetMajorVersion()
+    {
+        var version = ParseVersion(DatabaseProductVersion);
+        return version?.Major;
+    }
+
+    public int? GetPostgreSqlMajorVersion()
+    {
+        if (Product != SupportedDatabase.PostgreSql) return null;
+
+        return GetMajorVersion();
+    }
+
+    private static Version? ParseVersion(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input)) return null;
+
+        var match = Regex.Match(input, "(?<ver>\\d+(?:\\.\\d+)*)");
+        if (match.Success && Version.TryParse(match.Groups["ver"].Value, out var v))
+            return v;
+
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- add version parser and major-version helper
- check merge capability via `GetMajorVersion`
- test major version parsing for all providers
- note version detection in README
- tweak logic to use `> 14` instead of `>= 15`

## Testing
- `dotnet test pengdows.crud.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e790356508325bcee16a9f1c8ece5