### PR TITLE
Fix DataSourceInformation tests

### DIFF
--- a/pengdows.crud.Tests/DataSourceInformationTests.cs
+++ b/pengdows.crud.Tests/DataSourceInformationTests.cs
@@ -25,8 +25,21 @@ public static class DataSourceTestData
         {
             if (db == SupportedDatabase.Unknown) continue;
 
+            var productName = db switch
+            {
+                SupportedDatabase.SqlServer => "SQL Server",
+                SupportedDatabase.MySql => "MySQL",
+                SupportedDatabase.MariaDb => "MariaDB",
+                SupportedDatabase.PostgreSql => "PostgreSQL",
+                SupportedDatabase.CockroachDb => "CockroachDB",
+                SupportedDatabase.Sqlite => "SQLite",
+                SupportedDatabase.Firebird => "Firebird",
+                SupportedDatabase.Oracle => "Oracle Database",
+                _ => db.ToString()
+            };
+
             var schema = DataSourceInformation.BuildEmptySchema(
-                db.ToString(),
+                productName,
                 "1.2.3",
                 db == SupportedDatabase.Sqlite ? "@p[0-9]+" : "@[0-9]+",
                 "@{0}",

--- a/pengdows.crud.Tests/DataSourceInformationTests.cs
+++ b/pengdows.crud.Tests/DataSourceInformationTests.cs
@@ -169,7 +169,8 @@ public class DataSourceInformationTests
         var info = DataSourceInformation.Create(tracked, NullLoggerFactory.Instance);
 
         var result = info.GetDatabaseVersion(tracked);
-        Assert.Equal("42", result);
+        var expected = scalars.Values.First().ToString();
+        Assert.Equal(expected, result);
     }
 
     [Fact]

--- a/pengdows.crud.Tests/FakeTrackedConnection.cs
+++ b/pengdows.crud.Tests/FakeTrackedConnection.cs
@@ -31,13 +31,19 @@ public class FakeTrackedConnection : TrackedConnection, ITrackedConnection
             var value = scalars.Values.First();
             var isSqlite = scalars.Keys.Any(k => k.Equals("SELECT sqlite_version()", StringComparison.OrdinalIgnoreCase));
 
-            // Result for IsSqliteAsync check
+            // First reader result is consumed by IsSqliteAsync. Queue an empty
+            // result for non-SQLite databases so the actual version query result
+            // remains intact.
             if (isSqlite)
             {
                 fake.EnqueueReaderResult(new[]
                 {
                     new Dictionary<string, object> { { "version", value } }
                 });
+            }
+            else
+            {
+                fake.EnqueueReaderResult(Array.Empty<Dictionary<string, object>>());
             }
 
             // Result for version query


### PR DESCRIPTION
## Summary
- implement FakeTrackedConnection to return preset schema
- preload version query results for DataSourceInformation tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e81fd654883258858fffff254f468