### PR TITLE
Compute audit flag once

### DIFF
--- a/pengdows.crud.Tests/TypeMapRegistryTests.cs
+++ b/pengdows.crud.Tests/TypeMapRegistryTests.cs
@@ -60,6 +60,28 @@ public class TypeMapRegistryTests
         Assert.Contains("does not have a TableAttribute", ex.Message);
     }
 
+    [Fact]
+    public void GetTableInfo_SetsHasAuditColumns_WhenPresent()
+    {
+        var registry = new TypeMapRegistry();
+        registry.Register<AuditOnOnlyEntity>();
+
+        var info = registry.GetTableInfo<AuditOnOnlyEntity>();
+
+        Assert.True(info.HasAuditColumns);
+    }
+
+    [Fact]
+    public void GetTableInfo_SetsHasAuditColumnsFalse_WhenAbsent()
+    {
+        var registry = new TypeMapRegistry();
+        registry.Register<MyEntity>();
+
+        var info = registry.GetTableInfo<MyEntity>();
+
+        Assert.False(info.HasAuditColumns);
+    }
+
     [Table("MultipleVersions")]
     private class MultipleVersions
     {

--- a/pengdows.crud.abstractions/ITableInfo.cs
+++ b/pengdows.crud.abstractions/ITableInfo.cs
@@ -11,4 +11,9 @@ public interface ITableInfo
     IColumnInfo LastUpdatedOn { get; set; }
     IColumnInfo CreatedOn { get; set; }
     IColumnInfo CreatedBy { get; set; }
+
+    /// <summary>
+    /// Indicates whether any audit-related columns are configured for the table.
+    /// </summary>
+    bool HasAuditColumns { get; set; }
 }

--- a/pengdows.crud/EntityHelper.cs
+++ b/pengdows.crud/EntityHelper.cs
@@ -43,6 +43,7 @@ public class EntityHelper<TEntity, TRowID> :
 
     // private readonly IServiceProvider _serviceProvider;
     private ITableInfo _tableInfo;
+    private bool _hasAuditColumns;
     private Type? _userFieldType = null;
 
     private IColumnInfo? _versionColumn;
@@ -70,6 +71,7 @@ public class EntityHelper<TEntity, TRowID> :
         _context = databaseContext;
         _tableInfo = _context.TypeMapRegistry.GetTableInfo<TEntity>() ??
                      throw new InvalidOperationException($"Type {typeof(TEntity).FullName} is not a table.");
+        _hasAuditColumns = _tableInfo.HasAuditColumns;
 
         var propertyInfoPropertyType = _tableInfo.Columns
             .Values
@@ -956,10 +958,7 @@ public class EntityHelper<TEntity, TRowID> :
             return;
 
         // Skip resolving audit values when no audit columns are present
-        if (_tableInfo.CreatedBy == null &&
-            _tableInfo.CreatedOn == null &&
-            _tableInfo.LastUpdatedBy == null &&
-            _tableInfo.LastUpdatedOn == null)
+        if (!_hasAuditColumns)
             return;
 
         var auditValues = _auditValueResolver?.Resolve();

--- a/pengdows.crud/TableInfo.cs
+++ b/pengdows.crud/TableInfo.cs
@@ -11,4 +11,9 @@ public class TableInfo : ITableInfo
     public IColumnInfo LastUpdatedOn { get; set; }
     public IColumnInfo CreatedOn { get; set; }
     public IColumnInfo CreatedBy { get; set; }
+
+    /// <summary>
+    /// Indicates whether this table contains any audit columns.
+    /// </summary>
+    public bool HasAuditColumns { get; set; }
 }

--- a/pengdows.crud/TypeMapRegistry.cs
+++ b/pengdows.crud/TypeMapRegistry.cs
@@ -86,6 +86,11 @@ public class TypeMapRegistry : ITypeMapRegistry
                 }
             }
 
+            tableInfo.HasAuditColumns = tableInfo.CreatedBy != null ||
+                                        tableInfo.CreatedOn != null ||
+                                        tableInfo.LastUpdatedBy != null ||
+                                        tableInfo.LastUpdatedOn != null;
+
             _typeMap[type] = tableInfo;
         }
 


### PR DESCRIPTION
## Summary
- add `HasAuditColumns` property to `ITableInfo` and `TableInfo`
- compute audit flag once when building table info
- use cached `_hasAuditColumns` flag in `EntityHelper` to skip repeated checks

## Testing
- ❌ `dotnet test --no-build` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880d57a6ee08325aef606d5db7c4e50