### PR TITLE
Implement cached SQL templates

### DIFF
--- a/pengdows.crud.Tests/CachedSqlTemplatesTests.cs
+++ b/pengdows.crud.Tests/CachedSqlTemplatesTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace pengdows.crud.Tests;
+
+public class CachedSqlTemplatesTests : SqlLiteContextTestBase
+{
+    [Fact]
+    public void BuildCreate_ReusesCachedTemplates()
+    {
+        TypeMap.Register<TestEntity>();
+        var helper1 = new EntityHelper<TestEntity, int>(Context);
+        var helper2 = new EntityHelper<TestEntity, int>(Context);
+        var entity1 = new TestEntity { Name = "one" };
+        var entity2 = new TestEntity { Name = "two" };
+
+        helper1.BuildCreate(entity1);
+        var field = typeof(EntityHelper<TestEntity, int>).GetField("_cachedSqlTemplates", BindingFlags.Static | BindingFlags.NonPublic)!;
+        var lazy1 = field.GetValue(null)!;
+        var valueProp = lazy1.GetType().GetProperty("Value")!;
+        var template1 = valueProp.GetValue(lazy1);
+
+        helper2.BuildCreate(entity2);
+        var lazy2 = field.GetValue(null)!;
+        var template2 = valueProp.GetValue(lazy2);
+
+        Assert.Same(template1, template2);
+    }
+
+    [Fact]
+    public async Task BuildUpdateAsync_ReusesCachedTemplates()
+    {
+        TypeMap.Register<TestEntity>();
+        var helper1 = new EntityHelper<TestEntity, int>(Context);
+        var helper2 = new EntityHelper<TestEntity, int>(Context);
+
+        var entity1 = new TestEntity { Id = 1, Name = "one" };
+        var entity2 = new TestEntity { Id = 1, Name = "two" };
+
+        await helper1.BuildUpdateAsync(entity1);
+        var field = typeof(EntityHelper<TestEntity, int>).GetField("_cachedSqlTemplates", BindingFlags.Static | BindingFlags.NonPublic)!;
+        var lazy = field.GetValue(null)!;
+        var valueProp = lazy.GetType().GetProperty("Value")!;
+        var template1 = valueProp.GetValue(lazy);
+
+        await helper2.BuildUpdateAsync(entity2);
+        var template2 = valueProp.GetValue(lazy);
+
+        Assert.Same(template1, template2);
+    }
+}

--- a/pengdows.crud.Tests/DataSourceInformationNegativeTests.cs
+++ b/pengdows.crud.Tests/DataSourceInformationNegativeTests.cs
@@ -97,4 +97,19 @@ public class DataSourceInformationNegativeTests
         using var tracked = new TrackedConnection(conn);
         Assert.True(InvokeIsSqliteSync(tracked));
     }
+
+    [Fact]
+    public void MaxOutputParameters_UnknownProduct_DefaultsToZero()
+    {
+        var schema = DataSourceInformation.BuildEmptySchema(
+            "UnknownDb", "1", "@", "@{0}", 64, "@\\w+", "@\\w+", true);
+        var factory = new FakeDbFactory(SupportedDatabase.SqlServer);
+        var conn = factory.CreateConnection();
+        conn.ConnectionString = $"Data Source=test;EmulatedProduct={SupportedDatabase.Unknown}";
+        using var tracked = new FakeTrackedConnection(conn, schema, new Dictionary<string, object>());
+
+        var info = DataSourceInformation.Create(tracked, NullLoggerFactory.Instance);
+
+        Assert.Equal(0, info.MaxOutputParameters);
+    }
 }

--- a/pengdows.crud.Tests/DataSourceInformationTests.cs
+++ b/pengdows.crud.Tests/DataSourceInformationTests.cs
@@ -155,6 +155,21 @@ public class DataSourceInformationTests
         // Assert: named parameters flags
         Assert.Equal(db != SupportedDatabase.Unknown, info.SupportsNamedParameters);
         Assert.Equal(expectedRequiresStoredProcParameterNameMatch, info.RequiresStoredProcParameterNameMatch);
+
+        // Assert: output parameter limits
+        var expectedOutputParams = db switch
+        {
+            SupportedDatabase.SqlServer => 1024,
+            SupportedDatabase.MySql => 65535,
+            SupportedDatabase.MariaDb => 65535,
+            SupportedDatabase.PostgreSql => 100,
+            SupportedDatabase.CockroachDb => 100,
+            SupportedDatabase.Oracle => 1024,
+            SupportedDatabase.Sqlite => 0,
+            SupportedDatabase.Firebird => 1499,
+            _ => 0
+        };
+        Assert.Equal(expectedOutputParams, info.MaxOutputParameters);
     }
 
     [Theory]

--- a/pengdows.crud.Tests/DatabaseContextTests.cs
+++ b/pengdows.crud.Tests/DatabaseContextTests.cs
@@ -233,7 +233,8 @@ public class DatabaseContextTests
         var factory = new FakeDbFactory(product);
         var context = new DatabaseContext($"Data Source=test;EmulatedProduct={product}", factory);
         var name = context.MakeParameterName("foo");
-        Assert.StartsWith(context.DataSourceInfo.ParameterMarker, name);
+        var expected = context.DataSourceInfo.ParameterMarker + "foo";
+        Assert.Equal(expected, name);
     }
 
     [Theory]

--- a/pengdows.crud.Tests/DatabaseContextTests.cs
+++ b/pengdows.crud.Tests/DatabaseContextTests.cs
@@ -286,4 +286,14 @@ public class DatabaseContextTests
 
         Assert.Equal("?", context.MakeParameterName(param));
     }
+
+    [Fact]
+    public void MaxOutputParameters_ExposedViaContext()
+    {
+        var product = SupportedDatabase.SqlServer;
+        var factory = new FakeDbFactory(product);
+        var context = new DatabaseContext($"Data Source=test;EmulatedProduct={product}", factory);
+
+        Assert.Equal(context.DataSourceInfo.MaxOutputParameters, context.MaxOutputParameters);
+    }
 }

--- a/pengdows.crud.Tests/DatabaseContextTests.cs
+++ b/pengdows.crud.Tests/DatabaseContextTests.cs
@@ -221,4 +221,27 @@ public class DatabaseContextTests
         var name = context.MakeParameterName("foo");
         Assert.StartsWith(context.DataSourceInfo.ParameterMarker, name);
     }
+
+    [Theory]
+    [InlineData("@foo")]
+    [InlineData(":foo")]
+    [InlineData("?foo")]
+    public void MakeParameterName_ReturnsAlreadyPrefixedName(string existing)
+    {
+        var product = SupportedDatabase.Sqlite;
+        var factory = new FakeDbFactory(product);
+        var context = new DatabaseContext($"Data Source=test;EmulatedProduct={product}", factory);
+        var name = context.MakeParameterName(existing);
+        Assert.Equal(existing, name);
+    }
+
+    [Fact]
+    public void MakeParameterName_NoNamedParameters_ReturnsQuestionMark()
+    {
+        var product = SupportedDatabase.Unknown;
+        var factory = new FakeDbFactory(product);
+        var context = new DatabaseContext($"Data Source=test;EmulatedProduct={product}", factory);
+        Assert.Equal("?", context.MakeParameterName("foo"));
+        Assert.Equal("?", context.MakeParameterName("@foo"));
+    }
 }

--- a/pengdows.crud.Tests/EntityHelperNegativeTests.cs
+++ b/pengdows.crud.Tests/EntityHelperNegativeTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using pengdows.crud.enums;
 using pengdows.crud.exceptions;
 using pengdows.crud.FakeDb;
+using pengdows.crud.attributes;
 using Xunit;
 
 namespace pengdows.crud.Tests;
@@ -94,6 +95,27 @@ public class EntityHelperNegativeTests : SqlLiteContextTestBase
         var entity = new TestEntity { Id = 1, Name = "foo" };
 
         Assert.Throws<NotSupportedException>(() => localHelper.BuildUpsert(entity));
+    }
+
+    [Fact]
+    public void BuildCreate_NullEntity_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => helper.BuildCreate(null!));
+    }
+
+    [Fact]
+    public void BuildDelete_NoIdColumn_Throws()
+    {
+        TypeMap.Register<EntityWithoutId>();
+        var local = new EntityHelper<EntityWithoutId, int>(Context);
+        Assert.Throws<InvalidOperationException>(() => local.BuildDelete(1));
+    }
+
+    [Table("NoIdTable")]
+    private class EntityWithoutId
+    {
+        [Column("Name", DbType.String)]
+        public string Name { get; set; } = string.Empty;
     }
 
     private async Task BuildTestTable()

--- a/pengdows.crud.Tests/EntityHelperNegativeTests.cs
+++ b/pengdows.crud.Tests/EntityHelperNegativeTests.cs
@@ -111,6 +111,15 @@ public class EntityHelperNegativeTests : SqlLiteContextTestBase
         Assert.Throws<InvalidOperationException>(() => local.BuildDelete(1));
     }
 
+    [Fact]
+    public void BuildCreate_NoIdColumn_Throws()
+    {
+        TypeMap.Register<EntityWithoutId>();
+        var local = new EntityHelper<EntityWithoutId, int>(Context);
+        var entity = new EntityWithoutId { Name = "foo" };
+        Assert.Throws<InvalidOperationException>(() => local.BuildCreate(entity));
+    }
+
     [Table("NoIdTable")]
     private class EntityWithoutId
     {

--- a/pengdows.crud.Tests/IDataSourceInformationTests.cs
+++ b/pengdows.crud.Tests/IDataSourceInformationTests.cs
@@ -17,5 +17,6 @@ public class IDataSourceInformationTests
         var info = new DataSourceInformation(conn, NullLoggerFactory.Instance);
         Assert.False(string.IsNullOrWhiteSpace(info.CompositeIdentifierSeparator));
         Assert.False(string.IsNullOrWhiteSpace(info.ParameterMarker));
+        Assert.True(info.MaxOutputParameters >= 0);
     }
 }

--- a/pengdows.crud.Tests/NonInsertableColumnEntity.cs
+++ b/pengdows.crud.Tests/NonInsertableColumnEntity.cs
@@ -1,0 +1,20 @@
+using System.Data;
+using pengdows.crud.attributes;
+
+namespace pengdows.crud.Tests;
+
+[Table("NonInsertableColumnEntity")]
+public class NonInsertableColumnEntity
+{
+    [Id]
+    [Column("Id", DbType.Int32)]
+    public int Id { get; set; }
+
+    [Column("Name", DbType.String)]
+    public string Name { get; set; } = string.Empty;
+
+    [NonInsertable]
+    [NonUpdateable]
+    [Column("Secret", DbType.String)]
+    public string? Secret { get; set; }
+}

--- a/pengdows.crud.Tests/NonInsertableNonUpdateableColumnTests.cs
+++ b/pengdows.crud.Tests/NonInsertableNonUpdateableColumnTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading.Tasks;
+using pengdows.crud;
+using Xunit;
+
+namespace pengdows.crud.Tests;
+
+public class NonInsertableNonUpdateableColumnTests : SqlLiteContextTestBase
+{
+    [Fact]
+    public void BuildCreate_SkipsNonInsertableColumn()
+    {
+        TypeMap.Register<NonInsertableColumnEntity>();
+        var helper = new EntityHelper<NonInsertableColumnEntity, int>(Context);
+        var entity = new NonInsertableColumnEntity { Id = 1, Name = "Foo", Secret = "Bar" };
+
+        var container = helper.BuildCreate(entity);
+        var sql = container.Query.ToString();
+
+        var columnSecret = Context.WrapObjectName("Secret");
+        var columnName = Context.WrapObjectName("Name");
+        Assert.DoesNotContain(columnSecret, sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(columnName, sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task BuildUpdate_SkipsNonUpdateableColumn()
+    {
+        TypeMap.Register<NonInsertableColumnEntity>();
+        var helper = new EntityHelper<NonInsertableColumnEntity, int>(Context);
+        var entity = new NonInsertableColumnEntity { Id = 1, Name = "Foo", Secret = "Bar" };
+
+        var sc = await helper.BuildUpdateAsync(entity);
+        var sql = sc.Query.ToString();
+
+        var columnSecret = Context.WrapObjectName("Secret");
+        var columnName = Context.WrapObjectName("Name");
+        Assert.DoesNotContain(columnSecret, sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(columnName, sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task BuildUpdateAsync_OnlyNonUpdateableChanged_Throws()
+    {
+        TypeMap.Register<NonInsertableColumnEntity>();
+        var helper = new EntityHelper<NonInsertableColumnEntity, int>(Context);
+
+        var qp = Context.QuotePrefix;
+        var qs = Context.QuoteSuffix;
+        var createTableSql = $"CREATE TABLE IF NOT EXISTS {qp}NonInsertableColumnEntity{qs} ({qp}Id{qs} INTEGER PRIMARY KEY, {qp}Name{qs} TEXT, {qp}Secret{qs} TEXT)";
+        var tableContainer = Context.CreateSqlContainer();
+        tableContainer.Query.Append(createTableSql);
+        await tableContainer.ExecuteNonQueryAsync();
+
+        var original = new NonInsertableColumnEntity { Id = 1, Name = "Foo", Secret = "Original" };
+        var insert = helper.BuildCreate(original);
+        await insert.ExecuteNonQueryAsync();
+
+        var updated = new NonInsertableColumnEntity { Id = 1, Name = "Foo", Secret = "Changed" };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await helper.BuildUpdateAsync(updated, true));
+    }
+}

--- a/pengdows.crud.abstractions/IDataSourceInformation.cs
+++ b/pengdows.crud.abstractions/IDataSourceInformation.cs
@@ -80,6 +80,11 @@ public interface IDataSourceInformation
     int MaxParameterLimit { get; }
 
     /// <summary>
+    /// Gets the maximum number of output parameters supported in a command.
+    /// </summary>
+    int MaxOutputParameters { get; }
+
+    /// <summary>
     /// Gets the detected database product as an enumeration value.
     /// </summary>
     SupportedDatabase Product { get; }

--- a/pengdows.crud.abstractions/IDatabaseContext.cs
+++ b/pengdows.crud.abstractions/IDatabaseContext.cs
@@ -49,6 +49,11 @@ public interface IDatabaseContext : ISafeAsyncDisposableBase
     int MaxParameterLimit { get; }
 
     /// <summary>
+    /// The hard limit of output parameters this provider supports per statement.
+    /// </summary>
+    int MaxOutputParameters { get; }
+
+    /// <summary>
     /// Current number of open connections. Usually 0 for DbMode.Standard, 1 otherwise.
     /// </summary>
     long NumberOfOpenConnections { get; }

--- a/pengdows.crud/DataSourceInformation.cs
+++ b/pengdows.crud/DataSourceInformation.cs
@@ -40,6 +40,18 @@ public class DataSourceInformation : IDataSourceInformation
         { SupportedDatabase.Firebird, 1499 }
     };
 
+    private static readonly Dictionary<SupportedDatabase, int> MaxOutputParameterLimits = new()
+    {
+        { SupportedDatabase.SqlServer, 1024 },
+        { SupportedDatabase.MySql, 65535 },
+        { SupportedDatabase.MariaDb, 65535 },
+        { SupportedDatabase.PostgreSql, 100 },
+        { SupportedDatabase.CockroachDb, 100 },
+        { SupportedDatabase.Oracle, 1024 },
+        { SupportedDatabase.Sqlite, 0 },
+        { SupportedDatabase.Firebird, 1499 }
+    };
+
     private static readonly Dictionary<SupportedDatabase, ProcWrappingStyle> ProcWrapStyles = new()
     {
         { SupportedDatabase.SqlServer, ProcWrappingStyle.Exec },
@@ -98,6 +110,7 @@ public class DataSourceInformation : IDataSourceInformation
     public bool PrepareStatements { get; private set; }
     public ProcWrappingStyle ProcWrappingStyle { get; set; }
     public int MaxParameterLimit { get; private set; }
+    public int MaxOutputParameters { get; private set; }
     public string CompositeIdentifierSeparator { get; private set; } = ".";
 
     public string GetDatabaseVersion(ITrackedConnection connection)
@@ -240,6 +253,7 @@ public class DataSourceInformation : IDataSourceInformation
         SupportsNamedParameters |= ParameterMarker != "?";
         ProcWrappingStyle = ProcWrapStyles.GetValueOrDefault(Product, ProcWrappingStyle.None);
         MaxParameterLimit = MaxParameterLimits.GetValueOrDefault(Product, 999);
+        MaxOutputParameters = MaxOutputParameterLimits.GetValueOrDefault(Product, 0);
     }
 
     private static DataTable ReadSqliteSchema()

--- a/pengdows.crud/DatabaseContext.cs
+++ b/pengdows.crud/DatabaseContext.cs
@@ -35,6 +35,8 @@ public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext
     private bool _isWriteConnection = true;
     private long _maxNumberOfOpenConnections;
 
+    private static readonly char[] _parameterPrefixes = { '@', '?', ':' };
+
     [Obsolete("Use the constructor that takes DatabaseContextConfiguration instead.")]
     public DatabaseContext(
         string connectionString,
@@ -319,6 +321,16 @@ public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext
 
     private static string StripParameterPrefixes(string name)
     {
+        if (string.IsNullOrEmpty(name))
+        {
+            return string.Empty;
+        }
+
+        if (name.IndexOfAny(_parameterPrefixes) == -1)
+        {
+            return name;
+        }
+
         return name
             .Replace("@", string.Empty)
             .Replace("?", string.Empty)

--- a/pengdows.crud/DatabaseContext.cs
+++ b/pengdows.crud/DatabaseContext.cs
@@ -298,9 +298,24 @@ public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext
 
     public string MakeParameterName(string parameterName)
     {
-        return !_dataSourceInfo.SupportsNamedParameters
-            ? "?"
-            : $"{_dataSourceInfo.ParameterMarker}{parameterName}";
+        if (!_dataSourceInfo.SupportsNamedParameters)
+        {
+            return "?";
+        }
+
+        if (!string.IsNullOrEmpty(parameterName))
+        {
+            var first = parameterName[0];
+            switch (first)
+            {
+                case '?':
+                case ':':
+                case '@':
+                    return parameterName;
+            }
+        }
+
+        return _dataSourceInfo.ParameterMarker + parameterName;
     }
 
 

--- a/pengdows.crud/DatabaseContext.cs
+++ b/pengdows.crud/DatabaseContext.cs
@@ -346,6 +346,8 @@ public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext
 
     public int MaxParameterLimit => _dataSourceInfo.MaxParameterLimit;
 
+    public int MaxOutputParameters => _dataSourceInfo.MaxOutputParameters;
+
     public long MaxNumberOfConnections => Interlocked.Read(ref _maxNumberOfOpenConnections);
 
     public long NumberOfOpenConnections => Interlocked.Read(ref _connectionCount);

--- a/pengdows.crud/TransactionContext.cs
+++ b/pengdows.crud/TransactionContext.cs
@@ -103,6 +103,7 @@ public class TransactionContext : SafeAsyncDisposableBase, ITransactionContext
     public bool IsReadOnlyConnection => _context.IsReadOnlyConnection;
     public bool RCSIEnabled => _context.RCSIEnabled;
     public int MaxParameterLimit => _context.MaxParameterLimit;
+    public int MaxOutputParameters => _context.MaxOutputParameters;
     public DbMode ConnectionMode => DbMode.SingleConnection;
     public ITypeMapRegistry TypeMapRegistry => _context.TypeMapRegistry;
     public IDataSourceInformation DataSourceInfo => _context.DataSourceInfo;

--- a/pengdows.crud/TypeMapRegistry.cs
+++ b/pengdows.crud/TypeMapRegistry.cs
@@ -12,7 +12,14 @@ namespace pengdows.crud;
 
 public class TypeMapRegistry : ITypeMapRegistry
 {
+    public static TypeMapRegistry StaticInstance { get; private set; } = new();
+
     private readonly ConcurrentDictionary<Type, TableInfo> _typeMap = new();
+
+    public TypeMapRegistry()
+    {
+        StaticInstance = this;
+    }
 
     public ITableInfo GetTableInfo<T>()
     {


### PR DESCRIPTION
## Summary
- add CachedSqlTemplates lazy cache in `EntityHelper`
- generate INSERT, UPDATE, and DELETE templates once
- refactor `BuildCreate`, `BuildUpdateAsync`, and `BuildDelete` to use the cache
- add tests verifying cached template reuse for create and update

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d5c3b8b8c83258f5fb400e9c87b9a