### PR TITLE
Implement cached SQL templates

### DIFF
--- a/pengdows.crud.Tests/CachedSqlTemplatesTests.cs
+++ b/pengdows.crud.Tests/CachedSqlTemplatesTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace pengdows.crud.Tests;
+
+public class CachedSqlTemplatesTests : SqlLiteContextTestBase
+{
+    [Fact]
+    public void BuildCreate_ReusesCachedTemplates()
+    {
+        TypeMap.Register<TestEntity>();
+        var helper1 = new EntityHelper<TestEntity, int>(Context);
+        var helper2 = new EntityHelper<TestEntity, int>(Context);
+        var entity1 = new TestEntity { Name = "one" };
+        var entity2 = new TestEntity { Name = "two" };
+
+        helper1.BuildCreate(entity1);
+        var field = typeof(EntityHelper<TestEntity, int>).GetField("_cachedSqlTemplates", BindingFlags.Static | BindingFlags.NonPublic)!;
+        var lazy1 = field.GetValue(null)!;
+        var valueProp = lazy1.GetType().GetProperty("Value")!;
+        var template1 = valueProp.GetValue(lazy1);
+
+        helper2.BuildCreate(entity2);
+        var lazy2 = field.GetValue(null)!;
+        var template2 = valueProp.GetValue(lazy2);
+
+        Assert.Same(template1, template2);
+    }
+
+    [Fact]
+    public void BuildCreate_UsesPredictableParameterNames()
+    {
+        TypeMap.Register<TestEntity>();
+        var helper = new EntityHelper<TestEntity, int>(Context);
+        var entity = new TestEntity { Name = "foo" };
+
+        var sc = helper.BuildCreate(entity);
+
+        var sql = sc.Query.ToString();
+        Assert.Contains("@p0", sql);
+        Assert.Contains("@p1", sql);
+
+        var field = typeof(SqlContainer).GetField("_parameters", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var parameters = (Dictionary<string, DbParameter>)field.GetValue(sc)!;
+        Assert.Contains("p0", parameters.Keys);
+        Assert.Contains("p1", parameters.Keys);
+    }
+
+    [Fact]
+    public async Task BuildUpdateAsync_ReusesCachedTemplates()
+    {
+        TypeMap.Register<TestEntity>();
+        var helper1 = new EntityHelper<TestEntity, int>(Context);
+        var helper2 = new EntityHelper<TestEntity, int>(Context);
+
+        var entity1 = new TestEntity { Id = 1, Name = "one" };
+        var entity2 = new TestEntity { Id = 1, Name = "two" };
+
+        await helper1.BuildUpdateAsync(entity1);
+        var field = typeof(EntityHelper<TestEntity, int>).GetField("_cachedSqlTemplates", BindingFlags.Static | BindingFlags.NonPublic)!;
+        var lazy = field.GetValue(null)!;
+        var valueProp = lazy.GetType().GetProperty("Value")!;
+        var template1 = valueProp.GetValue(lazy);
+
+        await helper2.BuildUpdateAsync(entity2);
+        var template2 = valueProp.GetValue(lazy);
+
+        Assert.Same(template1, template2);
+    }
+}

--- a/pengdows.crud.Tests/CachedSqlTemplatesTests.cs
+++ b/pengdows.crud.Tests/CachedSqlTemplatesTests.cs
@@ -2,8 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Reflection;
-using System.Threading.Tasks;
+using System.Threading.Tasks; 
 using Microsoft.Data.Sqlite;
+ 
 using Xunit;
 
 namespace pengdows.crud.Tests;
@@ -61,17 +62,21 @@ public class CachedSqlTemplatesTests : SqlLiteContextTestBase
         var entity1 = new TestEntity { Id = 1, Name = "one" };
         var entity2 = new TestEntity { Id = 1, Name = "two" };
 
+ 
         await helper1.BuildUpdateAsync(entity1, loadOriginal: false);
+ 
         var field = typeof(EntityHelper<TestEntity, int>).GetField("_cachedSqlTemplates", BindingFlags.Static | BindingFlags.NonPublic)!;
         var lazy = field.GetValue(null)!;
         var valueProp = lazy.GetType().GetProperty("Value")!;
         var template1 = valueProp.GetValue(lazy);
-
+ 
         await helper2.BuildUpdateAsync(entity2, loadOriginal: false);
+ 
         var template2 = valueProp.GetValue(lazy);
 
         Assert.Same(template1, template2);
     }
+ 
 
     [Fact]
     public async Task BuildUpdateAsync_WhenLoadOriginalTrue_ThrowsIfTableMissing()
@@ -83,4 +88,5 @@ public class CachedSqlTemplatesTests : SqlLiteContextTestBase
         await Assert.ThrowsAsync<SqliteException>(async () =>
             await helper.BuildUpdateAsync(entity, loadOriginal: true));
     }
+ 
 }

--- a/pengdows.crud.Tests/DataSourceInformationNegativeTests.cs
+++ b/pengdows.crud.Tests/DataSourceInformationNegativeTests.cs
@@ -97,4 +97,19 @@ public class DataSourceInformationNegativeTests
         using var tracked = new TrackedConnection(conn);
         Assert.True(InvokeIsSqliteSync(tracked));
     }
+
+    [Fact]
+    public void MaxOutputParameters_UnknownProduct_DefaultsToZero()
+    {
+        var schema = DataSourceInformation.BuildEmptySchema(
+            "UnknownDb", "1", "@", "@{0}", 64, "@\\w+", "@\\w+", true);
+        var factory = new FakeDbFactory(SupportedDatabase.SqlServer);
+        var conn = factory.CreateConnection();
+        conn.ConnectionString = $"Data Source=test;EmulatedProduct={SupportedDatabase.Unknown}";
+        using var tracked = new FakeTrackedConnection(conn, schema, new Dictionary<string, object>());
+
+        var info = DataSourceInformation.Create(tracked, NullLoggerFactory.Instance);
+
+        Assert.Equal(0, info.MaxOutputParameters);
+    }
 }

--- a/pengdows.crud.Tests/DataSourceInformationTests.cs
+++ b/pengdows.crud.Tests/DataSourceInformationTests.cs
@@ -155,6 +155,21 @@ public class DataSourceInformationTests
         // Assert: named parameters flags
         Assert.Equal(db != SupportedDatabase.Unknown, info.SupportsNamedParameters);
         Assert.Equal(expectedRequiresStoredProcParameterNameMatch, info.RequiresStoredProcParameterNameMatch);
+
+        // Assert: output parameter limits
+        var expectedOutputParams = db switch
+        {
+            SupportedDatabase.SqlServer => 1024,
+            SupportedDatabase.MySql => 65535,
+            SupportedDatabase.MariaDb => 65535,
+            SupportedDatabase.PostgreSql => 100,
+            SupportedDatabase.CockroachDb => 100,
+            SupportedDatabase.Oracle => 1024,
+            SupportedDatabase.Sqlite => 0,
+            SupportedDatabase.Firebird => 1499,
+            _ => 0
+        };
+        Assert.Equal(expectedOutputParams, info.MaxOutputParameters);
     }
 
     [Theory]

--- a/pengdows.crud.Tests/DatabaseContextIsolationTests.cs
+++ b/pengdows.crud.Tests/DatabaseContextIsolationTests.cs
@@ -45,4 +45,13 @@ public class DatabaseContextIsolationTests
             new FakeDbFactory(SupportedDatabase.CockroachDb.ToString()));
         Assert.Throws<NotSupportedException>(() => context.BeginTransaction(IsolationProfile.FastWithRisks));
     }
+
+    [Fact]
+    public void BeginTransaction_UnknownProduct_Throws()
+    {
+        var context = new DatabaseContext($"Data Source=test;EmulatedProduct={SupportedDatabase.Unknown}",
+            new FakeDbFactory(SupportedDatabase.Unknown.ToString()));
+
+        Assert.Throws<NotSupportedException>(() => context.BeginTransaction(IsolationProfile.StrictConsistency));
+    }
 }

--- a/pengdows.crud.Tests/DatabaseContextTests.cs
+++ b/pengdows.crud.Tests/DatabaseContextTests.cs
@@ -80,11 +80,23 @@ public class DatabaseContextTests
     {
         var factory = new FakeDbFactory(product);
         var context = new DatabaseContext($"Data Source=test;EmulatedProduct={product}", factory);
-        var result = context.CreateDbParameter("p1", DbType.Int32, 123);
+        var result = context.CreateDbParameter("p1", DbType.Int32, 123, ParameterDirection.Output);
 
         Assert.Equal("p1", result.ParameterName);
         Assert.Equal(DbType.Int32, result.DbType);
         Assert.Equal(123, result.Value);
+        Assert.Equal(ParameterDirection.Output, result.Direction);
+    }
+
+    [Theory]
+    [MemberData(nameof(AllSupportedProviders))]
+    public void CreateDbParameter_DefaultsDirectionToInput(SupportedDatabase product)
+    {
+        var factory = new FakeDbFactory(product);
+        var context = new DatabaseContext($"Data Source=test;EmulatedProduct={product}", factory);
+        var result = context.CreateDbParameter("p1", DbType.Int32, 123);
+
+        Assert.Equal(ParameterDirection.Input, result.Direction);
     }
 
     [Theory]

--- a/pengdows.crud.Tests/DatabaseContextTests.cs
+++ b/pengdows.crud.Tests/DatabaseContextTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Runtime.Serialization;
 using Moq;
 using pengdows.crud.configuration;
 using pengdows.crud.enums;
@@ -307,5 +308,23 @@ public class DatabaseContextTests
         var context = new DatabaseContext($"Data Source=test;EmulatedProduct={product}", factory);
 
         Assert.Equal(context.DataSourceInfo.MaxOutputParameters, context.MaxOutputParameters);
+    }
+
+    [Fact]
+    public void Product_WhenInitialized_ReturnsProvidedProduct()
+    {
+        var product = SupportedDatabase.SqlServer;
+        var factory = new FakeDbFactory(product);
+        var context = new DatabaseContext($"Data Source=test;EmulatedProduct={product}", factory);
+
+        Assert.Equal(product, context.Product);
+    }
+
+    [Fact]
+    public void Product_WithoutDataSourceInfo_ReturnsUnknown()
+    {
+        var context = (DatabaseContext)FormatterServices.GetUninitializedObject(typeof(DatabaseContext));
+
+        Assert.Equal(SupportedDatabase.Unknown, context.Product);
     }
 }

--- a/pengdows.crud.Tests/DatabaseContextTests.cs
+++ b/pengdows.crud.Tests/DatabaseContextTests.cs
@@ -115,6 +115,20 @@ public class DatabaseContextTests
     }
 
     [Theory]
+    [InlineData("@foo", "foo")]
+    [InlineData(":bar", "bar")]
+    [InlineData("?baz", "baz")]
+    public void CreateDbParameter_RemovesPrefixesFromName(string input, string expected)
+    {
+        var product = SupportedDatabase.Sqlite;
+        var factory = new FakeDbFactory(product);
+        var context = new DatabaseContext($"Data Source=test;EmulatedProduct={product}", factory);
+        var result = context.CreateDbParameter(input, DbType.String, "v");
+
+        Assert.Equal(expected, result.ParameterName);
+    }
+
+    [Theory]
     [MemberData(nameof(AllSupportedProviders))]
     public async Task CloseAndDisposeConnectionAsync_WithAsyncDisposable_DisposesCorrectly(SupportedDatabase product)
     {
@@ -308,6 +322,7 @@ public class DatabaseContextTests
         var context = new DatabaseContext($"Data Source=test;EmulatedProduct={product}", factory);
 
         Assert.Equal(context.DataSourceInfo.MaxOutputParameters, context.MaxOutputParameters);
+ 
     }
 
     [Fact]
@@ -326,5 +341,6 @@ public class DatabaseContextTests
         var context = (DatabaseContext)FormatterServices.GetUninitializedObject(typeof(DatabaseContext));
 
         Assert.Equal(SupportedDatabase.Unknown, context.Product);
+ 
     }
 }

--- a/pengdows.crud.Tests/DatabaseContextTests.cs
+++ b/pengdows.crud.Tests/DatabaseContextTests.cs
@@ -88,6 +88,20 @@ public class DatabaseContextTests
     }
 
     [Theory]
+    [InlineData("@foo", "foo")]
+    [InlineData(":bar", "bar")]
+    [InlineData("?baz", "baz")]
+    public void CreateDbParameter_RemovesPrefixesFromName(string input, string expected)
+    {
+        var product = SupportedDatabase.Sqlite;
+        var factory = new FakeDbFactory(product);
+        var context = new DatabaseContext($"Data Source=test;EmulatedProduct={product}", factory);
+        var result = context.CreateDbParameter(input, DbType.String, "v");
+
+        Assert.Equal(expected, result.ParameterName);
+    }
+
+    [Theory]
     [MemberData(nameof(AllSupportedProviders))]
     public async Task CloseAndDisposeConnectionAsync_WithAsyncDisposable_DisposesCorrectly(SupportedDatabase product)
     {
@@ -219,6 +233,67 @@ public class DatabaseContextTests
         var factory = new FakeDbFactory(product);
         var context = new DatabaseContext($"Data Source=test;EmulatedProduct={product}", factory);
         var name = context.MakeParameterName("foo");
-        Assert.StartsWith(context.DataSourceInfo.ParameterMarker, name);
+        var expected = context.DataSourceInfo.ParameterMarker + "foo";
+        Assert.Equal(expected, name);
+    }
+
+    [Theory]
+    [InlineData("@foo")]
+    [InlineData(":foo")]
+    [InlineData("?foo")]
+    [InlineData("@:foo?")]
+    public void MakeParameterName_StripsExistingPrefixes(string input)
+    {
+        var product = SupportedDatabase.Sqlite;
+        var factory = new FakeDbFactory(product);
+        var context = new DatabaseContext($"Data Source=test;EmulatedProduct={product}", factory);
+        var name = context.MakeParameterName(input);
+        var expected = context.DataSourceInfo.ParameterMarker + "foo";
+        Assert.Equal(expected, name);
+    }
+
+    [Fact]
+    public void MakeParameterName_NoNamedParameters_ReturnsQuestionMark()
+    {
+        var product = SupportedDatabase.Unknown;
+        var factory = new FakeDbFactory(product);
+        var context = new DatabaseContext($"Data Source=test;EmulatedProduct={product}", factory);
+        Assert.Equal("?", context.MakeParameterName("foo"));
+        Assert.Equal("?", context.MakeParameterName("@foo"));
+        Assert.Equal("?", context.MakeParameterName(":foo"));
+    }
+
+    [Fact]
+    public void MakeParameterName_DbParameter_StripsPrefixes()
+    {
+        var product = SupportedDatabase.Sqlite;
+        var factory = new FakeDbFactory(product);
+        var context = new DatabaseContext($"Data Source=test;EmulatedProduct={product}", factory);
+        var param = new FakeDbParameter { ParameterName = ":foo", DbType = DbType.String, Value = "x" };
+
+        var name = context.MakeParameterName(param);
+
+        Assert.Equal(context.DataSourceInfo.ParameterMarker + "foo", name);
+    }
+
+    [Fact]
+    public void MakeParameterName_DbParameter_NoNamedParameters_ReturnsQuestionMark()
+    {
+        var product = SupportedDatabase.Unknown;
+        var factory = new FakeDbFactory(product);
+        var context = new DatabaseContext($"Data Source=test;EmulatedProduct={product}", factory);
+        var param = new FakeDbParameter { ParameterName = "@foo", DbType = DbType.String, Value = "x" };
+
+        Assert.Equal("?", context.MakeParameterName(param));
+    }
+
+    [Fact]
+    public void MaxOutputParameters_ExposedViaContext()
+    {
+        var product = SupportedDatabase.SqlServer;
+        var factory = new FakeDbFactory(product);
+        var context = new DatabaseContext($"Data Source=test;EmulatedProduct={product}", factory);
+
+        Assert.Equal(context.DataSourceInfo.MaxOutputParameters, context.MaxOutputParameters);
     }
 }

--- a/pengdows.crud.Tests/EntityHelperBuildWhereByPrimaryKeyTests.cs
+++ b/pengdows.crud.Tests/EntityHelperBuildWhereByPrimaryKeyTests.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace pengdows.crud.Tests;
+
+public class EntityHelperBuildWhereByPrimaryKeyTests : SqlLiteContextTestBase
+{
+    private readonly EntityHelper<TestEntity, int> _helper;
+
+    public EntityHelperBuildWhereByPrimaryKeyTests()
+    {
+        TypeMap.Register<TestEntity>();
+        _helper = new EntityHelper<TestEntity, int>(Context);
+    }
+
+    [Fact]
+    public void BuildWhereByPrimaryKey_GeneratesExpectedWhereClause()
+    {
+        var sc = Context.CreateSqlContainer();
+        var list = new List<TestEntity>
+        {
+            new() { Name = "A" },
+            new() { Name = "B" }
+        };
+
+        _helper.BuildWhereByPrimaryKey(list, sc, "t");
+        var sql = sc.Query.ToString();
+
+        var pattern = "\\n WHERE \\(t\\.\"Name\" = @\\w+\\) OR \\(t\\.\"Name\" = @\\w+\\)";
+        Assert.Matches(pattern, sql);
+        Assert.Equal(2, sc.ParameterCount);
+    }
+}
+

--- a/pengdows.crud.Tests/EntityHelperNegativeTests.cs
+++ b/pengdows.crud.Tests/EntityHelperNegativeTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using pengdows.crud.enums;
 using pengdows.crud.exceptions;
 using pengdows.crud.FakeDb;
+using pengdows.crud.attributes;
 using Xunit;
 
 namespace pengdows.crud.Tests;
@@ -94,6 +95,36 @@ public class EntityHelperNegativeTests : SqlLiteContextTestBase
         var entity = new TestEntity { Id = 1, Name = "foo" };
 
         Assert.Throws<NotSupportedException>(() => localHelper.BuildUpsert(entity));
+    }
+
+    [Fact]
+    public void BuildCreate_NullEntity_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => helper.BuildCreate(null!));
+    }
+
+    [Fact]
+    public void BuildDelete_NoIdColumn_Throws()
+    {
+        TypeMap.Register<EntityWithoutId>();
+        var local = new EntityHelper<EntityWithoutId, int>(Context);
+        Assert.Throws<InvalidOperationException>(() => local.BuildDelete(1));
+    }
+
+    [Fact]
+    public void BuildCreate_NoIdColumn_Throws()
+    {
+        TypeMap.Register<EntityWithoutId>();
+        var local = new EntityHelper<EntityWithoutId, int>(Context);
+        var entity = new EntityWithoutId { Name = "foo" };
+        Assert.Throws<InvalidOperationException>(() => local.BuildCreate(entity));
+    }
+
+    [Table("NoIdTable")]
+    private class EntityWithoutId
+    {
+        [Column("Name", DbType.String)]
+        public string Name { get; set; } = string.Empty;
     }
 
     private async Task BuildTestTable()

--- a/pengdows.crud.Tests/FakeDbConnectionTests.cs
+++ b/pengdows.crud.Tests/FakeDbConnectionTests.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Data;
+using pengdows.crud.FakeDb;
+using pengdows.crud.enums;
+using Xunit;
+
+namespace pengdows.crud.Tests;
+
+public class FakeDbConnectionTests
+{
+    [Fact]
+    public void GetSchema_UnknownProduct_ReturnsDefaultSchema()
+    {
+        var conn = new FakeDbConnection();
+        conn.ConnectionString = $"Data Source=test;EmulatedProduct={SupportedDatabase.Unknown}";
+        conn.Open();
+        var schema = conn.GetSchema();
+        Assert.False(schema.Rows[0].Field<bool>("SupportsNamedParameters"));
+    }
+
+    [Fact]
+    public void GetSchema_EmulatedProductNotConfigured_Throws()
+    {
+        var conn = new FakeDbConnection();
+        Assert.Throws<InvalidOperationException>(() => conn.GetSchema());
+    }
+}

--- a/pengdows.crud.Tests/FakeDbNullabilityTests.cs
+++ b/pengdows.crud.Tests/FakeDbNullabilityTests.cs
@@ -1,0 +1,51 @@
+using System.Threading.Tasks;
+using pengdows.crud.FakeDb;
+using Xunit;
+
+namespace pengdows.crud.Tests;
+
+public class FakeDbNullabilityTests
+{
+    [Fact]
+    public void FakeDbParameter_PropertiesAllowNull()
+    {
+        var p = new FakeDbParameter
+        {
+            ParameterName = null,
+            SourceColumn = null,
+            Value = null
+        };
+
+        Assert.Null(p.ParameterName);
+        Assert.Null(p.SourceColumn);
+        Assert.Null(p.Value);
+
+        p.ParameterName = "p1";
+        p.SourceColumn = "c1";
+        p.Value = 5;
+
+        Assert.Equal("p1", p.ParameterName);
+        Assert.Equal("c1", p.SourceColumn);
+        Assert.Equal(5, p.Value);
+    }
+
+    [Fact]
+    public async Task FakeDbCommand_CommandTextAllowsNullAndExecuteScalarAsync()
+    {
+        var cmd = new FakeDbCommand();
+        cmd.CommandText = null;
+        Assert.Null(cmd.CommandText);
+        cmd.CommandText = "SELECT 1";
+        Assert.Equal("SELECT 1", cmd.CommandText);
+
+        var conn = new FakeDbConnection();
+        var cmdWithConn = new FakeDbCommand(conn);
+
+        var defaultResult = await cmdWithConn.ExecuteScalarAsync(default);
+        Assert.Equal(42, defaultResult);
+
+        conn.ScalarResults.Enqueue(7);
+        var queuedResult = await cmdWithConn.ExecuteScalarAsync(default);
+        Assert.Equal(7, queuedResult);
+    }
+}

--- a/pengdows.crud.Tests/IDataSourceInformationTests.cs
+++ b/pengdows.crud.Tests/IDataSourceInformationTests.cs
@@ -17,5 +17,6 @@ public class IDataSourceInformationTests
         var info = new DataSourceInformation(conn, NullLoggerFactory.Instance);
         Assert.False(string.IsNullOrWhiteSpace(info.CompositeIdentifierSeparator));
         Assert.False(string.IsNullOrWhiteSpace(info.ParameterMarker));
+        Assert.True(info.MaxOutputParameters >= 0);
     }
 }

--- a/pengdows.crud.Tests/NonInsertableColumnEntity.cs
+++ b/pengdows.crud.Tests/NonInsertableColumnEntity.cs
@@ -1,0 +1,20 @@
+using System.Data;
+using pengdows.crud.attributes;
+
+namespace pengdows.crud.Tests;
+
+[Table("NonInsertableColumnEntity")]
+public class NonInsertableColumnEntity
+{
+    [Id]
+    [Column("Id", DbType.Int32)]
+    public int Id { get; set; }
+
+    [Column("Name", DbType.String)]
+    public string Name { get; set; } = string.Empty;
+
+    [NonInsertable]
+    [NonUpdateable]
+    [Column("Secret", DbType.String)]
+    public string? Secret { get; set; }
+}

--- a/pengdows.crud.Tests/NonInsertableNonUpdateableColumnTests.cs
+++ b/pengdows.crud.Tests/NonInsertableNonUpdateableColumnTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading.Tasks;
+using pengdows.crud;
+using Xunit;
+
+namespace pengdows.crud.Tests;
+
+public class NonInsertableNonUpdateableColumnTests : SqlLiteContextTestBase
+{
+    [Fact]
+    public void BuildCreate_SkipsNonInsertableColumn()
+    {
+        TypeMap.Register<NonInsertableColumnEntity>();
+        var helper = new EntityHelper<NonInsertableColumnEntity, int>(Context);
+        var entity = new NonInsertableColumnEntity { Id = 1, Name = "Foo", Secret = "Bar" };
+
+        var container = helper.BuildCreate(entity);
+        var sql = container.Query.ToString();
+
+        var columnSecret = Context.WrapObjectName("Secret");
+        var columnName = Context.WrapObjectName("Name");
+        Assert.DoesNotContain(columnSecret, sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(columnName, sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task BuildUpdate_SkipsNonUpdateableColumn()
+    {
+        TypeMap.Register<NonInsertableColumnEntity>();
+        var helper = new EntityHelper<NonInsertableColumnEntity, int>(Context);
+        var entity = new NonInsertableColumnEntity { Id = 1, Name = "Foo", Secret = "Bar" };
+
+        var sc = await helper.BuildUpdateAsync(entity);
+        var sql = sc.Query.ToString();
+
+        var columnSecret = Context.WrapObjectName("Secret");
+        var columnName = Context.WrapObjectName("Name");
+        Assert.DoesNotContain(columnSecret, sql, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(columnName, sql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task BuildUpdateAsync_OnlyNonUpdateableChanged_Throws()
+    {
+        TypeMap.Register<NonInsertableColumnEntity>();
+        var helper = new EntityHelper<NonInsertableColumnEntity, int>(Context);
+
+        var qp = Context.QuotePrefix;
+        var qs = Context.QuoteSuffix;
+        var createTableSql = $"CREATE TABLE IF NOT EXISTS {qp}NonInsertableColumnEntity{qs} ({qp}Id{qs} INTEGER PRIMARY KEY, {qp}Name{qs} TEXT, {qp}Secret{qs} TEXT)";
+        var tableContainer = Context.CreateSqlContainer();
+        tableContainer.Query.Append(createTableSql);
+        await tableContainer.ExecuteNonQueryAsync();
+
+        var original = new NonInsertableColumnEntity { Id = 1, Name = "Foo", Secret = "Original" };
+        var insert = helper.BuildCreate(original);
+        await insert.ExecuteNonQueryAsync();
+
+        var updated = new NonInsertableColumnEntity { Id = 1, Name = "Foo", Secret = "Changed" };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () => await helper.BuildUpdateAsync(updated, true));
+    }
+}

--- a/pengdows.crud.Tests/ProcWrappingStyleTests.cs
+++ b/pengdows.crud.Tests/ProcWrappingStyleTests.cs
@@ -69,6 +69,15 @@ public class ProcWrappingStyleTests
     }
 
     [Fact]
+    public void WrapTestExecCaptureReturn()
+    {
+        var sc = SetupParameterWrapTest();
+        _dbContext.ProcWrappingStyle = ProcWrappingStyle.Exec;
+        var s = sc.WrapForStoredProc(ExecutionType.Read, captureReturn: true);
+        Assert.Equal("DECLARE @__ret INT;\nEXEC @__ret = dbo.Sqltest @p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9;\nSELECT @__ret;", s);
+    }
+
+    [Fact]
     public void WrapTestExecute()
     {
         var sc = SetupParameterWrapTest();
@@ -95,5 +104,13 @@ public class ProcWrappingStyleTests
         _dbContext.ProcWrappingStyle = ProcWrappingStyle.Oracle;
         var s = sc.WrapForStoredProc(ExecutionType.Read);
         Assert.Equal("BEGIN\n\tdbo.Sqltest(@p0, @p1, @p2, @p3, @p4, @p5, @p6, @p7, @p8, @p9);\nEND;", s);
+    }
+
+    [Fact]
+    public void CaptureReturn_UnsupportedStyle_ShouldThrow()
+    {
+        var sc = SetupParameterWrapTest();
+        _dbContext.ProcWrappingStyle = ProcWrappingStyle.Call;
+        Assert.Throws<NotSupportedException>(() => sc.WrapForStoredProc(ExecutionType.Read, captureReturn: true));
     }
 }

--- a/pengdows.crud.Tests/SqlContainerTests.cs
+++ b/pengdows.crud.Tests/SqlContainerTests.cs
@@ -63,6 +63,24 @@ public class SqlContainerTests : SqlLiteContextTestBase
     }
 
     [Fact]
+    public void AddParameterWithValue_SetsDirection()
+    {
+        var container = Context.CreateSqlContainer();
+        var param = container.AddParameterWithValue("p1", DbType.Int32, 1, ParameterDirection.Output);
+
+        Assert.Equal(ParameterDirection.Output, param.Direction);
+    }
+
+    [Fact]
+    public void AddParameterWithValue_DefaultsDirectionToInput()
+    {
+        var container = Context.CreateSqlContainer();
+        var param = container.AddParameterWithValue("p1", DbType.Int32, 1);
+
+        Assert.Equal(ParameterDirection.Input, param.Direction);
+    }
+
+    [Fact]
     public async Task ExecuteNonQueryAsync_InsertsData()
     {
         var qp = Context.QuotePrefix;

--- a/pengdows.crud.Tests/SqlContainerTests.cs
+++ b/pengdows.crud.Tests/SqlContainerTests.cs
@@ -63,12 +63,21 @@ public class SqlContainerTests : SqlLiteContextTestBase
     }
 
     [Fact]
-    public void AddParameterWithValue_SetsDirection()
+    public void AddParameterWithValue_UnsupportedDirectionThrows()
     {
         var container = Context.CreateSqlContainer();
-        var param = container.AddParameterWithValue("p1", DbType.Int32, 1, ParameterDirection.Output);
 
-        Assert.Equal(ParameterDirection.Output, param.Direction);
+        Assert.Throws<ArgumentException>(() =>
+            container.AddParameterWithValue("p1", DbType.Int32, 1, ParameterDirection.Output));
+    }
+
+    [Fact]
+    public void AddParameterWithValue_SetsExplicitInputDirection()
+    {
+        var container = Context.CreateSqlContainer();
+        var param = container.AddParameterWithValue("p1", DbType.Int32, 1, ParameterDirection.Input);
+
+        Assert.Equal(ParameterDirection.Input, param.Direction);
     }
 
     [Fact]

--- a/pengdows.crud.Tests/TransactionContextTests.cs
+++ b/pengdows.crud.Tests/TransactionContextTests.cs
@@ -219,6 +219,26 @@ public class TransactionContextTests
     }
 
     [Fact]
+    public void CreateDbParameter_ForwardsDirection()
+    {
+        var context = (DatabaseContext)CreateContext(SupportedDatabase.Sqlite);
+        using var tx = context.BeginTransaction();
+        var param = tx.CreateDbParameter("p1", DbType.String, "v", ParameterDirection.Output);
+
+        Assert.Equal(ParameterDirection.Output, param.Direction);
+    }
+
+    [Fact]
+    public void CreateDbParameter_DefaultsDirectionToInput()
+    {
+        var context = (DatabaseContext)CreateContext(SupportedDatabase.Sqlite);
+        using var tx = context.BeginTransaction();
+        var param = tx.CreateDbParameter("p1", DbType.String, "v");
+
+        Assert.Equal(ParameterDirection.Input, param.Direction);
+    }
+
+    [Fact]
     public void ProcWrappingStyle_GetMatchesContext_SetterThrows()
     {
         var context = (DatabaseContext)CreateContext(SupportedDatabase.Sqlite);

--- a/pengdows.crud.Tests/WriteProcWithReturnTests.cs
+++ b/pengdows.crud.Tests/WriteProcWithReturnTests.cs
@@ -1,0 +1,83 @@
+#region
+
+using System;
+using System.Data;
+using Microsoft.Data.Sqlite;
+using pengdows.crud.enums;
+using Xunit;
+
+#endregion
+
+namespace pengdows.crud.Tests;
+
+public class WriteProcWithReturnTests
+{
+    private DatabaseContext _dbContext;
+
+    private SqlContainer SetupContainer()
+    {
+        if (_dbContext == null)
+        {
+            _dbContext = new DatabaseContext("DataSource=:memory:", SqliteFactory.Instance);
+        }
+
+        var sc = _dbContext.CreateSqlContainer("dbo.Sqltest") as SqlContainer;
+        for (var i = 0; i < 2; i++)
+        {
+            sc.AddParameterWithValue($"p{i}", DbType.Int32, i);
+        }
+
+        return sc;
+    }
+
+    [Fact]
+    public void WrapForCreateWithReturn_ExecStyle_GeneratesSql()
+    {
+        var sc = SetupContainer();
+        _dbContext.ProcWrappingStyle = ProcWrappingStyle.Exec;
+        var s = sc.WrapForCreateWithReturn();
+        Assert.Equal("DECLARE @__ret INT;\nEXEC @__ret = dbo.Sqltest @p0, @p1;\nSELECT @__ret;", s);
+    }
+
+    [Fact]
+    public void WrapForCreateWithReturn_UnsupportedStyle_ShouldThrow()
+    {
+        var sc = SetupContainer();
+        _dbContext.ProcWrappingStyle = ProcWrappingStyle.Call;
+        Assert.Throws<NotSupportedException>(() => sc.WrapForCreateWithReturn());
+    }
+
+    [Fact]
+    public void WrapForUpdateWithReturn_ExecStyle_GeneratesSql()
+    {
+        var sc = SetupContainer();
+        _dbContext.ProcWrappingStyle = ProcWrappingStyle.Exec;
+        var s = sc.WrapForUpdateWithReturn();
+        Assert.Equal("DECLARE @__ret INT;\nEXEC @__ret = dbo.Sqltest @p0, @p1;\nSELECT @__ret;", s);
+    }
+
+    [Fact]
+    public void WrapForUpdateWithReturn_UnsupportedStyle_ShouldThrow()
+    {
+        var sc = SetupContainer();
+        _dbContext.ProcWrappingStyle = ProcWrappingStyle.Call;
+        Assert.Throws<NotSupportedException>(() => sc.WrapForUpdateWithReturn());
+    }
+
+    [Fact]
+    public void WrapForDeleteWithReturn_ExecStyle_GeneratesSql()
+    {
+        var sc = SetupContainer();
+        _dbContext.ProcWrappingStyle = ProcWrappingStyle.Exec;
+        var s = sc.WrapForDeleteWithReturn();
+        Assert.Equal("DECLARE @__ret INT;\nEXEC @__ret = dbo.Sqltest @p0, @p1;\nSELECT @__ret;", s);
+    }
+
+    [Fact]
+    public void WrapForDeleteWithReturn_UnsupportedStyle_ShouldThrow()
+    {
+        var sc = SetupContainer();
+        _dbContext.ProcWrappingStyle = ProcWrappingStyle.Call;
+        Assert.Throws<NotSupportedException>(() => sc.WrapForDeleteWithReturn());
+    }
+}

--- a/pengdows.crud.abstractions/IDataSourceInformation.cs
+++ b/pengdows.crud.abstractions/IDataSourceInformation.cs
@@ -80,6 +80,11 @@ public interface IDataSourceInformation
     int MaxParameterLimit { get; }
 
     /// <summary>
+    /// Gets the maximum number of output parameters supported in a command.
+    /// </summary>
+    int MaxOutputParameters { get; }
+
+    /// <summary>
     /// Gets the detected database product as an enumeration value.
     /// </summary>
     SupportedDatabase Product { get; }

--- a/pengdows.crud.abstractions/IDatabaseContext.cs
+++ b/pengdows.crud.abstractions/IDatabaseContext.cs
@@ -49,6 +49,11 @@ public interface IDatabaseContext : ISafeAsyncDisposableBase
     int MaxParameterLimit { get; }
 
     /// <summary>
+    /// The hard limit of output parameters this provider supports per statement.
+    /// </summary>
+    int MaxOutputParameters { get; }
+
+    /// <summary>
     /// Current number of open connections. Usually 0 for DbMode.Standard, 1 otherwise.
     /// </summary>
     long NumberOfOpenConnections { get; }

--- a/pengdows.crud.abstractions/IDatabaseContext.cs
+++ b/pengdows.crud.abstractions/IDatabaseContext.cs
@@ -118,12 +118,14 @@ public interface IDatabaseContext : ISafeAsyncDisposableBase
     /// <summary>
     /// Creates a named DbParameter.
     /// </summary>
-    DbParameter CreateDbParameter<T>(string? name, DbType type, T value);
+    DbParameter CreateDbParameter<T>(string? name, DbType type, T value,
+        ParameterDirection direction = ParameterDirection.Input);
 
     /// <summary>
     /// Creates a positional DbParameter (no name specified).
     /// </summary>
-    DbParameter CreateDbParameter<T>(DbType type, T value);
+    DbParameter CreateDbParameter<T>(DbType type, T value,
+        ParameterDirection direction = ParameterDirection.Input);
 
     /// <summary>
     /// Returns a tracked connection for the given execution type.

--- a/pengdows.crud.abstractions/ISqlContainer.cs
+++ b/pengdows.crud.abstractions/ISqlContainer.cs
@@ -55,7 +55,8 @@ public interface ISqlContainer : ISafeAsyncDisposableBase
     /// <param name="type">Database type of the parameter.</param>
     /// <param name="value">The value to assign.</param>
     /// <returns>The created parameter.</returns>
-    DbParameter AddParameterWithValue<T>(DbType type, T value);
+    DbParameter AddParameterWithValue<T>(DbType type, T value,
+        ParameterDirection direction = ParameterDirection.Input);
 
     /// <summary>
     /// Adds a named parameter by type and value.
@@ -65,7 +66,8 @@ public interface ISqlContainer : ISafeAsyncDisposableBase
     /// <param name="type">Database type of the parameter.</param>
     /// <param name="value">The value to assign.</param>
     /// <returns>The created parameter.</returns>
-    DbParameter AddParameterWithValue<T>(string? name, DbType type, T value);
+    DbParameter AddParameterWithValue<T>(string? name, DbType type, T value,
+        ParameterDirection direction = ParameterDirection.Input);
 
     /// <summary>
     /// Executes the current query as a non-query command.

--- a/pengdows.crud.abstractions/ISqlContainer.cs
+++ b/pengdows.crud.abstractions/ISqlContainer.cs
@@ -119,6 +119,27 @@ public interface ISqlContainer : ISafeAsyncDisposableBase
     string WrapForStoredProc(ExecutionType executionType, bool includeParameters = true, bool captureReturn = false);
 
     /// <summary>
+    /// Wraps the query for execution as a CREATE-like stored procedure and captures a return value.
+    /// </summary>
+    /// <param name="includeParameters">Whether to include parameters in the wrapper.</param>
+    /// <returns>The wrapped command text.</returns>
+    string WrapForCreateWithReturn(bool includeParameters = true);
+
+    /// <summary>
+    /// Wraps the query for execution as an UPDATE-like stored procedure and captures a return value.
+    /// </summary>
+    /// <param name="includeParameters">Whether to include parameters in the wrapper.</param>
+    /// <returns>The wrapped command text.</returns>
+    string WrapForUpdateWithReturn(bool includeParameters = true);
+
+    /// <summary>
+    /// Wraps the query for execution as a DELETE-like stored procedure and captures a return value.
+    /// </summary>
+    /// <param name="includeParameters">Whether to include parameters in the wrapper.</param>
+    /// <returns>The wrapped command text.</returns>
+    string WrapForDeleteWithReturn(bool includeParameters = true);
+
+    /// <summary>
     /// Wraps an object name using the current quoting rules.
     /// </summary>
     /// <param name="objectName">The name to wrap.</param>

--- a/pengdows.crud.abstractions/ISqlContainer.cs
+++ b/pengdows.crud.abstractions/ISqlContainer.cs
@@ -114,8 +114,9 @@ public interface ISqlContainer : ISafeAsyncDisposableBase
     /// </summary>
     /// <param name="executionType">The procedure execution type.</param>
     /// <param name="includeParameters">Whether to include parameters in the wrapper.</param>
+    /// <param name="captureReturn">Whether to capture a return value.</param>
     /// <returns>The wrapped command text.</returns>
-    string WrapForStoredProc(ExecutionType executionType, bool includeParameters = true);
+    string WrapForStoredProc(ExecutionType executionType, bool includeParameters = true, bool captureReturn = false);
 
     /// <summary>
     /// Wraps an object name using the current quoting rules.

--- a/pengdows.crud.fakeDb/FakeDbCommand.cs
+++ b/pengdows.crud.fakeDb/FakeDbCommand.cs
@@ -2,6 +2,7 @@
 
 using System.Data;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 
 #endregion
 
@@ -18,14 +19,17 @@ public sealed class FakeDbCommand : DbCommand
     {
     }
 
+    [AllowNull]
     public override string CommandText { get; set; }
     public override int CommandTimeout { get; set; }
     public override CommandType CommandType { get; set; }
     public override bool DesignTimeVisible { get; set; }
     public override UpdateRowSource UpdatedRowSource { get; set; }
 
+    [AllowNull]
     public new DbConnection Connection { get; set; }
     protected override DbConnection? DbConnection { get; set; }
+    [AllowNull]
     public new DbTransaction Transaction { get; set; }
 
     protected override DbParameterCollection DbParameterCollection
@@ -47,7 +51,10 @@ public sealed class FakeDbCommand : DbCommand
     {
         var conn = FakeConnection;
         if (conn != null && conn.NonQueryResults.Count > 0)
+        {
             return conn.NonQueryResults.Dequeue();
+        }
+
         return 1;
     }
 
@@ -55,7 +62,10 @@ public sealed class FakeDbCommand : DbCommand
     {
         var conn = FakeConnection;
         if (conn != null && conn.ScalarResults.Count > 0)
+        {
             return conn.ScalarResults.Dequeue();
+        }
+
         return 42;
     }
 
@@ -63,7 +73,10 @@ public sealed class FakeDbCommand : DbCommand
     {
         var conn = FakeConnection;
         if (conn != null && conn.ReaderResults.Count > 0)
+        {
             return new FakeDbDataReader(conn.ReaderResults.Dequeue());
+        }
+
         return new FakeDbDataReader();
     }
 
@@ -73,7 +86,7 @@ public sealed class FakeDbCommand : DbCommand
         return Task.FromResult(ExecuteNonQuery());
     }
 
-    public override Task<object> ExecuteScalarAsync(CancellationToken ct)
+    public override Task<object?> ExecuteScalarAsync(CancellationToken ct)
     {
         return Task.FromResult(ExecuteScalar());
     }

--- a/pengdows.crud.fakeDb/FakeDbConnection.cs
+++ b/pengdows.crud.fakeDb/FakeDbConnection.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using pengdows.crud.enums;
+using pengdows.crud;
 
 #endregion
 
@@ -138,10 +139,29 @@ public class FakeDbConnection : DbConnection, IDbConnection, IDisposable, IAsync
 
     public override DataTable GetSchema()
     {
-        if (_schemaTable != null) return _schemaTable;
+        if (_schemaTable != null)
+        {
+            return _schemaTable;
+        }
 
-        if (_emulatedProduct is null or SupportedDatabase.Unknown)
+        if (_emulatedProduct is null)
+        {
             throw new InvalidOperationException("EmulatedProduct must be configured via connection string.");
+        }
+
+        if (_emulatedProduct == SupportedDatabase.Unknown)
+        {
+            _schemaTable = DataSourceInformation.BuildEmptySchema(
+                "UnknownDb",
+                "1",
+                string.Empty,
+                string.Empty,
+                0,
+                string.Empty,
+                string.Empty,
+                false);
+            return _schemaTable;
+        }
 
         var resourceName = $"pengdows.crud.fakeDb.xml.{_emulatedProduct}.schema.xml";
 
@@ -157,10 +177,29 @@ public class FakeDbConnection : DbConnection, IDbConnection, IDisposable, IAsync
 
     public override DataTable GetSchema(string meta)
     {
-        if (_schemaTable != null) return _schemaTable;
+        if (_schemaTable != null)
+        {
+            return _schemaTable;
+        }
 
-        if (_emulatedProduct is null or SupportedDatabase.Unknown)
+        if (_emulatedProduct is null)
+        {
             throw new InvalidOperationException("EmulatedProduct must be configured via connection string.");
+        }
+
+        if (_emulatedProduct == SupportedDatabase.Unknown)
+        {
+            _schemaTable = DataSourceInformation.BuildEmptySchema(
+                "UnknownDb",
+                "1",
+                string.Empty,
+                string.Empty,
+                0,
+                string.Empty,
+                string.Empty,
+                false);
+            return _schemaTable;
+        }
 
         var resourceName = $"pengdows.crud.fakeDb.xml.{_emulatedProduct}.schema.xml";
 

--- a/pengdows.crud.fakeDb/FakeDbParameter.cs
+++ b/pengdows.crud.fakeDb/FakeDbParameter.cs
@@ -2,6 +2,7 @@
 
 using System.Data;
 using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
 
 #endregion
 
@@ -13,9 +14,16 @@ public class FakeDbParameter : DbParameter, IDbDataParameter
     public override DbType DbType { get; set; }
     public override ParameterDirection Direction { get; set; }
     public override bool IsNullable { get; set; }
+
+    [AllowNull]
     public override string ParameterName { get; set; }
+
+    [AllowNull]
     public override string SourceColumn { get; set; }
+
+    [AllowNull]
     public override object Value { get; set; }
+
     public override int Size { get; set; }
 
     public override void ResetDbType()

--- a/pengdows.crud/DataSourceInformation.cs
+++ b/pengdows.crud/DataSourceInformation.cs
@@ -40,6 +40,18 @@ public class DataSourceInformation : IDataSourceInformation
         { SupportedDatabase.Firebird, 1499 }
     };
 
+    private static readonly Dictionary<SupportedDatabase, int> MaxOutputParameterLimits = new()
+    {
+        { SupportedDatabase.SqlServer, 1024 },
+        { SupportedDatabase.MySql, 65535 },
+        { SupportedDatabase.MariaDb, 65535 },
+        { SupportedDatabase.PostgreSql, 100 },
+        { SupportedDatabase.CockroachDb, 100 },
+        { SupportedDatabase.Oracle, 1024 },
+        { SupportedDatabase.Sqlite, 0 },
+        { SupportedDatabase.Firebird, 1499 }
+    };
+
     private static readonly Dictionary<SupportedDatabase, ProcWrappingStyle> ProcWrapStyles = new()
     {
         { SupportedDatabase.SqlServer, ProcWrappingStyle.Exec },
@@ -98,6 +110,7 @@ public class DataSourceInformation : IDataSourceInformation
     public bool PrepareStatements { get; private set; }
     public ProcWrappingStyle ProcWrappingStyle { get; set; }
     public int MaxParameterLimit { get; private set; }
+    public int MaxOutputParameters { get; private set; }
     public string CompositeIdentifierSeparator { get; private set; } = ".";
 
     public string GetDatabaseVersion(ITrackedConnection connection)
@@ -240,6 +253,7 @@ public class DataSourceInformation : IDataSourceInformation
         SupportsNamedParameters |= ParameterMarker != "?";
         ProcWrappingStyle = ProcWrapStyles.GetValueOrDefault(Product, ProcWrappingStyle.None);
         MaxParameterLimit = MaxParameterLimits.GetValueOrDefault(Product, 999);
+        MaxOutputParameters = MaxOutputParameterLimits.GetValueOrDefault(Product, 0);
     }
 
     private static DataTable ReadSqliteSchema()

--- a/pengdows.crud/DatabaseContext.cs
+++ b/pengdows.crud/DatabaseContext.cs
@@ -193,7 +193,8 @@ public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext
         return new SqlContainer(this, query);
     }
 
-    public DbParameter CreateDbParameter<T>(string? name, DbType type, T value)
+    public DbParameter CreateDbParameter<T>(string? name, DbType type, T value,
+        ParameterDirection direction = ParameterDirection.Input)
     {
         var p = _factory.CreateParameter() ?? throw new InvalidOperationException("Failed to create parameter.");
 
@@ -215,6 +216,7 @@ public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext
             p.Size = Math.Max(s.Length, 1);
         }
 
+        p.Direction = direction;
         return p;
     }
 
@@ -252,9 +254,10 @@ public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext
     }
 
 
-    public DbParameter CreateDbParameter<T>(DbType type, T value)
+    public DbParameter CreateDbParameter<T>(DbType type, T value,
+        ParameterDirection direction = ParameterDirection.Input)
     {
-        return CreateDbParameter(null, type, value);
+        return CreateDbParameter(null, type, value, direction);
     }
 
     public void AssertIsReadConnection()

--- a/pengdows.crud/DatabaseContext.cs
+++ b/pengdows.crud/DatabaseContext.cs
@@ -181,18 +181,18 @@ public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext
 
     public ITransactionContext BeginTransaction(IsolationProfile isolationProfile)
     {
+        if (_isolationResolver == null)
+        {
+            throw new NotSupportedException("Isolation profiles not supported for unknown database.");
+        }
+
         return new TransactionContext(this, _isolationResolver.Resolve(isolationProfile));
     }
 
 
     public string CompositeIdentifierSeparator => _dataSourceInfo.CompositeIdentifierSeparator;
-    public SupportedDatabase Product
-    {
-        get
-        {
-            return _dataSourceInfo?.Product ?? SupportedDatabase.Unknown;
-        }
-    }
+
+    public SupportedDatabase Product => _dataSourceInfo?.Product ?? SupportedDatabase.Unknown;
 
     public ISqlContainer CreateSqlContainer(string? query = null)
     {
@@ -551,7 +551,7 @@ public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext
                 _connection = conn;
             }
 
-            if (_dataSourceInfo != null && _dataSourceInfo.Product != SupportedDatabase.Unknown)
+            if (Product != SupportedDatabase.Unknown)
             {
                 _isolationResolver ??= new IsolationResolver(Product, RCSIEnabled);
             }
@@ -562,7 +562,7 @@ public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext
         }
         finally
         {
-            if (_dataSourceInfo != null && _dataSourceInfo.Product != SupportedDatabase.Unknown)
+            if (Product != SupportedDatabase.Unknown)
             {
                 _isolationResolver ??= new IsolationResolver(Product, RCSIEnabled);
             }
@@ -673,63 +673,7 @@ public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext
 
         return GetSingleConnection();
     }
-    //
-    // private int _disposed; // 0=false, 1=true
-    //
-    //
-    // public void Dispose()
-    // {
-    //     Dispose(disposing: true);
-    // }
-    //
-    // public async ValueTask DisposeAsync()
-    // {
-    //     await DisposeAsyncCore().ConfigureAwait(false);
-    //     Dispose(disposing: false); // Finalizer path for unmanaged cleanup (if any)
-    // }
-    //
-    // protected virtual async ValueTask DisposeAsyncCore()
-    // {
-    //     if (Interlocked.Exchange(ref _disposed, 1) != 0)
-    //         return; // Already disposed
-    //
-    //     if (_connection is IAsyncDisposable asyncDisposable)
-    //     {
-    //         await asyncDisposable.DisposeAsync().ConfigureAwait(false);
-    //     }
-    //     else
-    //     {
-    //         _connection?.Dispose();
-    //     }
-    //
-    //     _connection = null;
-    // }
-    //
-    //
-    // protected virtual void Dispose(bool disposing)
-    // {
-    //     if (Interlocked.Exchange(ref _disposed, 1) != 0)
-    //         return; // Already disposed
-    //
-    //     if (disposing)
-    //     {
-    //         try
-    //         {
-    //             _connection?.Dispose();
-    //         }
-    //         catch
-    //         {
-    //             // Optional: log or suppress
-    //         }
-    //         finally
-    //         {
-    //             _connection = null;
-    //             GC.SuppressFinalize(this); // Suppress only here
-    //         }
-    //     }
-    //
-    //     // unmanaged cleanup if needed (none currently)
-    // }
+   
 
     protected override void DisposeManaged()
     {

--- a/pengdows.crud/DatabaseContext.cs
+++ b/pengdows.crud/DatabaseContext.cs
@@ -186,7 +186,13 @@ public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext
 
 
     public string CompositeIdentifierSeparator => _dataSourceInfo.CompositeIdentifierSeparator;
-    public SupportedDatabase Product => _dataSourceInfo.Product;
+    public SupportedDatabase Product
+    {
+        get
+        {
+            return _dataSourceInfo?.Product ?? SupportedDatabase.Unknown;
+        }
+    }
 
     public ISqlContainer CreateSqlContainer(string? query = null)
     {
@@ -544,7 +550,11 @@ public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext
                 ApplyConnectionSessionSettings(conn);
                 _connection = conn;
             }
-            _isolationResolver ??= new IsolationResolver(Product, RCSIEnabled);
+
+            if (_dataSourceInfo != null && _dataSourceInfo.Product != SupportedDatabase.Unknown)
+            {
+                _isolationResolver ??= new IsolationResolver(Product, RCSIEnabled);
+            }
         }
         catch(Exception ex){
             _logger.LogError(ex, ex.Message);
@@ -552,10 +562,16 @@ public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext
         }
         finally
         {
-            _isolationResolver ??= new IsolationResolver(Product, RCSIEnabled);
+            if (_dataSourceInfo != null && _dataSourceInfo.Product != SupportedDatabase.Unknown)
+            {
+                _isolationResolver ??= new IsolationResolver(Product, RCSIEnabled);
+            }
+
             if (mode == DbMode.Standard)
+            {
                 //if it is standard mode, we can close it.
                 conn?.Dispose();
+            }
         }
     }
 

--- a/pengdows.crud/EntityHelper.cs
+++ b/pengdows.crud/EntityHelper.cs
@@ -24,6 +24,18 @@ public class EntityHelper<TEntity, TRowID> :
     // Cache for compiled property setters
     private static readonly ConcurrentDictionary<PropertyInfo, Action<object, object?>> _propertySetters = new();
 
+    private static readonly Lazy<CachedSqlTemplates> _cachedSqlTemplates = new(BuildCachedSqlTemplates);
+
+    private class CachedSqlTemplates
+    {
+        public string InsertSql = null!;
+        public List<IColumnInfo> InsertColumns = null!;
+        public List<string> InsertParameterNames = null!;
+        public string DeleteSql = null!;
+        public string UpdateSql = null!;
+        public List<IColumnInfo> UpdateColumns = null!;
+    }
+
     private static ILogger _logger = NullLogger.Instance;
 
     public static ILogger Logger
@@ -147,82 +159,62 @@ public class EntityHelper<TEntity, TRowID> :
         return await sc.ExecuteNonQueryAsync() == 1;
     }
     
-    public ISqlContainer BuildCreate(TEntity objectToCreate, IDatabaseContext? context = null)
+    public ISqlContainer BuildCreate(TEntity entity, IDatabaseContext? context = null)
     {
-        if (objectToCreate == null)
-            throw new ArgumentNullException(nameof(objectToCreate));
+        if (entity == null)
+        {
+            throw new ArgumentNullException(nameof(entity));
+        }
 
         var ctx = context ?? _context;
-        var columns = new StringBuilder();
-        var values = new StringBuilder();
-        var parameters = new List<DbParameter>();
-
         var sc = ctx.CreateSqlContainer();
-        SetAuditFields(objectToCreate, false);
+        SetAuditFields(entity, false);
 
-        // Initialize version to 1 if a version column exists and the current value is unset
         if (_versionColumn != null)
         {
-            var current = _versionColumn.PropertyInfo.GetValue(objectToCreate);
+            var current = _versionColumn.PropertyInfo.GetValue(entity);
             if (current == null || Utils.IsZeroNumeric(current))
             {
-                var target = Nullable.GetUnderlyingType(_versionColumn.PropertyInfo.PropertyType) ??
-                             _versionColumn.PropertyInfo.PropertyType;
-
-                // Only set numeric version columns
+                var target = Nullable.GetUnderlyingType(_versionColumn.PropertyInfo.PropertyType) ?? _versionColumn.PropertyInfo.PropertyType;
                 if (Utils.IsZeroNumeric(Convert.ChangeType(0, target)))
                 {
                     var one = Convert.ChangeType(1, target);
-                    _versionColumn.PropertyInfo.SetValue(objectToCreate, one);
+                    _versionColumn.PropertyInfo.SetValue(entity, one);
                 }
             }
         }
-        foreach (var column in _tableInfo.Columns.Values)
+
+        var template = _cachedSqlTemplates.Value;
+        var columns = new List<string>();
+        var placeholders = new List<string>();
+
+        for (var i = 0; i < template.InsertColumns.Count; i++)
         {
-            if (column.IsNonInsertable) continue;
-            if (column.IsId && !column.IsIdIsWritable) continue;
+            var column = template.InsertColumns[i];
+            var value = column.MakeParameterValueFromField(entity);
 
-            var value = column.MakeParameterValueFromField(objectToCreate);
-
-            // If no audit resolver is provided and the value is null for a user audit column,
-            // skip including this column so database defaults will apply.
             if (_auditValueResolver == null &&
                 (column.IsCreatedBy || column.IsLastUpdatedBy) &&
                 Utils.IsNullOrDbNull(value))
+            {
                 continue;
-
-            if (columns.Length > 0)
-            {
-                columns.Append(", ");
-                values.Append(", ");
             }
 
-            var p = _context.CreateDbParameter(
-                column.DbType,
-                value
-            );
-
-            columns.Append(WrapObjectName(column.Name));
-            if (Utils.IsNullOrDbNull(value))
-            {
-                values.Append("NULL");
-            }
-            else
-            {
-                values.Append(MakeParameterName(p));
-                parameters.Add(p);
-            }
+            var paramName = template.InsertParameterNames[i];
+            var param = ctx.CreateDbParameter(paramName, column.DbType, value);
+            sc.AddParameter(param);
+            columns.Add(WrapObjectName(column.Name));
+            placeholders.Add(ctx.MakeParameterName(param));
         }
 
         sc.Query.Append("INSERT INTO ")
             .Append(WrappedTableName)
             .Append(" (")
-            .Append(columns)
+            .Append(string.Join(", ", columns))
             .Append(") VALUES (")
-            .Append(values)
+            .Append(string.Join(", ", placeholders))
             .Append(")");
 
-        sc.AddParameters(parameters);
         return sc;
     }
 
@@ -251,27 +243,16 @@ public class EntityHelper<TEntity, TRowID> :
         var ctx = context ?? _context;
         var sc = ctx.CreateSqlContainer();
 
-        var idCol = _idColumn;
-        if (idCol == null)
+        if (_idColumn == null)
+        {
             throw new InvalidOperationException($"row identity column for table {WrappedTableName} not found");
-
-        var p = _context.CreateDbParameter(idCol.DbType, id);
-        sc.AddParameter(p);
-
-        sc.Query.Append("DELETE FROM ")
-            .Append(WrappedTableName)
-            .Append(" WHERE ")
-            .Append(WrapObjectName(idCol.Name));
-        if (Utils.IsNullOrDbNull(p.Value))
-        {
-            sc.Query.Append(" IS NULL ");
-        }
-        else
-        {
-            sc.Query.Append(" = ");
-            sc.Query.Append(MakeParameterName(p));
         }
 
+        var param = ctx.CreateDbParameter(_idColumn.DbType, id);
+        sc.AddParameter(param);
+
+        var sql = string.Format(_cachedSqlTemplates.Value.DeleteSql, MakeParameterName(param));
+        sc.Query.Append(sql);
         return sc;
     }
 
@@ -529,6 +510,7 @@ public class EntityHelper<TEntity, TRowID> :
             throw new InvalidOperationException("Original record not found for update.");
 
         // Determine if any non-audit fields have changed before modifying audit values
+        var template = _cachedSqlTemplates.Value;
         var (preClause, _) = BuildSetClause(objectToUpdate, original, context);
         if (preClause.Length == 0)
             throw new InvalidOperationException("No changes detected for update.");
@@ -544,18 +526,17 @@ public class EntityHelper<TEntity, TRowID> :
             _idColumn.PropertyInfo.GetValue(objectToUpdate)!);
         parameters.Add(pId);
 
-        sc.Query.Append("UPDATE ")
-            .Append(WrappedTableName)
-            .Append(" SET ")
-            .Append(setClause)
-            .Append(" WHERE ")
-            .Append(WrapObjectName(_idColumn.Name))
-            .Append($" = {MakeParameterName(pId)}");
+        var sql = string.Format(template.UpdateSql, setClause, MakeParameterName(pId));
+        sc.Query.Append(sql);
 
         if (_versionColumn != null)
         {
             var versionValue = _versionColumn.MakeParameterValueFromField(objectToUpdate);
-            AppendVersionCondition(sc, versionValue, context, parameters);
+            var versionParam = AppendVersionCondition(sc, versionValue, context);
+            if (versionParam != null)
+            {
+                parameters.Add(versionParam);
+            }
         }
 
         sc.AddParameters(parameters);
@@ -644,19 +625,23 @@ public class EntityHelper<TEntity, TRowID> :
     {
         var clause = new StringBuilder();
         var parameters = new List<DbParameter>();
+        var template = _cachedSqlTemplates.Value;
 
-        foreach (var column in _tableInfo.Columns.Values)
+        for (var i = 0; i < template.UpdateColumns.Count; i++)
         {
-            if (column.IsId || column.IsVersion || column.IsNonUpdateable || column.IsCreatedBy || column.IsCreatedOn)
-                continue;
-
+            var column = template.UpdateColumns[i];
             var newValue = column.MakeParameterValueFromField(updated);
             var originalValue = original != null ? column.MakeParameterValueFromField(original) : null;
 
             if (original != null && Equals(newValue, originalValue))
+            {
                 continue;
+            }
 
-            if (clause.Length > 0) clause.Append(", ");
+            if (clause.Length > 0)
+            {
+                clause.Append(", ");
+            }
 
             if (newValue == null)
             {
@@ -678,19 +663,18 @@ public class EntityHelper<TEntity, TRowID> :
         setClause.Append($", {WrapObjectName(_versionColumn!.Name)} = {WrapObjectName(_versionColumn.Name)} + 1");
     }
 
-    private void AppendVersionCondition(ISqlContainer sc, object? versionValue, IDatabaseContext context, List<DbParameter> parameters)
+    private DbParameter? AppendVersionCondition(ISqlContainer sc, object? versionValue, IDatabaseContext context)
     {
         if (versionValue == null)
         {
             sc.Query.Append(" AND ").Append(WrapObjectName(_versionColumn!.Name)).Append(" IS NULL");
+            return null;
         }
-        else
-        {
-            var pVersion = context.CreateDbParameter(_versionColumn!.DbType, versionValue);
-            sc.Query.Append(" AND ").Append(WrapObjectName(_versionColumn.Name))
-                .Append($" = {MakeParameterName(pVersion)}");
-            parameters.Add(pVersion);
-        }
+
+        var pVersion = context.CreateDbParameter(_versionColumn!.DbType, versionValue);
+        sc.Query.Append(" AND ").Append(WrapObjectName(_versionColumn.Name))
+            .Append($" = {MakeParameterName(pVersion)}");
+        return pVersion;
     }
 
     private ISqlContainer BuildUpsertOnConflict(TEntity entity, IDatabaseContext context)
@@ -1031,6 +1015,60 @@ public class EntityHelper<TEntity, TRowID> :
             return false;
         }
         return int.TryParse(match.Groups[1].Value, out major);
+    }
+
+    private static CachedSqlTemplates BuildCachedSqlTemplates()
+    {
+        var typeMap = TypeMapRegistry.StaticInstance.GetTableInfo<TEntity>() ?? throw new InvalidOperationException($"Type {typeof(TEntity).FullName} is not registered in TypeMapRegistry.");
+
+        var idCol = typeMap.Columns.Values.FirstOrDefault(c => c.IsId) ?? throw new InvalidOperationException($"No ID column defined for {typeof(TEntity).Name}");
+
+        var insertColumns = typeMap.Columns.Values
+            .Where(c => !c.IsNonInsertable && (!c.IsId || c.IsIdIsWritable))
+            .Cast<IColumnInfo>()
+            .ToList();
+
+        var wrappedCols = new List<string>();
+        for (var i = 0; i < insertColumns.Count; i++)
+        {
+            wrappedCols.Add(QuoteWrap(insertColumns[i].Name));
+        }
+
+        var paramNames = new List<string>();
+        var valuePlaceholders = new List<string>();
+        for (var i = 0; i < insertColumns.Count; i++)
+        {
+            var name = $"p{i}";
+            paramNames.Add(name);
+            valuePlaceholders.Add($"@{name}");
+        }
+
+        var insertSql = $"INSERT INTO {BuildWrappedTableName(typeMap)} ({string.Join(", ", wrappedCols)}) VALUES ({string.Join(", ", valuePlaceholders)})";
+        var deleteSql = $"DELETE FROM {BuildWrappedTableName(typeMap)} WHERE {QuoteWrap(idCol.Name)} = {{0}}";
+
+        var updateColumns = typeMap.Columns.Values
+            .Where(c => !c.IsId && !c.IsVersion && !c.IsNonUpdateable && !c.IsCreatedBy && !c.IsCreatedOn)
+            .Cast<IColumnInfo>()
+            .ToList();
+
+        var updateSql = $"UPDATE {BuildWrappedTableName(typeMap)} SET {{0}} WHERE {QuoteWrap(idCol.Name)} = {{1}}";
+
+        return new CachedSqlTemplates
+        {
+            InsertSql = insertSql,
+            InsertColumns = insertColumns,
+            InsertParameterNames = paramNames,
+            DeleteSql = deleteSql,
+            UpdateSql = updateSql,
+            UpdateColumns = updateColumns
+        };
+
+        static string QuoteWrap(string name) => '"' + name + '"';
+
+        static string BuildWrappedTableName(ITableInfo info)
+        {
+            return (string.IsNullOrWhiteSpace(info.Schema) ? string.Empty : QuoteWrap(info.Schema) + ".") + QuoteWrap(info.Name);
+        }
     }
 
     private static void ValidateRowIdType()

--- a/pengdows.crud/SqlContainer.cs
+++ b/pengdows.crud/SqlContainer.cs
@@ -75,17 +75,22 @@ public class SqlContainer : SafeAsyncDisposableBase, ISqlContainer
         _parameters.Add(parameter.ParameterName, parameter);
     }
 
-    public DbParameter AddParameterWithValue<T>(DbType type, T value)
+    public DbParameter AddParameterWithValue<T>(DbType type, T value,
+        ParameterDirection direction = ParameterDirection.Input)
     {
-        if (value is DbParameter) throw new ArgumentException("Parameter type can't be DbParameter.");
+        if (value is DbParameter)
+        {
+            throw new ArgumentException("Parameter type can't be DbParameter.");
+        }
 
-        return AddParameterWithValue(null, type, value);
+        return AddParameterWithValue(null, type, value, direction);
     }
 
-    public DbParameter AddParameterWithValue<T>(string? name, DbType type, T value)
+    public DbParameter AddParameterWithValue<T>(string? name, DbType type, T value,
+        ParameterDirection direction = ParameterDirection.Input)
     {
         name ??= GenerateRandomName();
-        var parameter = _context.CreateDbParameter(name, type, value);
+        var parameter = _context.CreateDbParameter(name, type, value, direction);
         AddParameter(parameter);
         return parameter;
     }

--- a/pengdows.crud/SqlContainer.cs
+++ b/pengdows.crud/SqlContainer.cs
@@ -89,8 +89,9 @@ public class SqlContainer : SafeAsyncDisposableBase, ISqlContainer
     public DbParameter AddParameterWithValue<T>(string? name, DbType type, T value,
         ParameterDirection direction = ParameterDirection.Input)
     {
-        name ??= GenerateRandomName();
+        name ??= GenerateRandomName(); 
         var parameter = _context.CreateDbParameter(name, type, value, direction);
+ 
         AddParameter(parameter);
         return parameter;
     }

--- a/pengdows.crud/SqlContainer.cs
+++ b/pengdows.crud/SqlContainer.cs
@@ -181,6 +181,21 @@ public class SqlContainer : SafeAsyncDisposableBase, ISqlContainer
         }
     }
 
+    public string WrapForCreateWithReturn(bool includeParameters = true)
+    {
+        return WrapForStoredProc(ExecutionType.Write, includeParameters, captureReturn: true);
+    }
+
+    public string WrapForUpdateWithReturn(bool includeParameters = true)
+    {
+        return WrapForStoredProc(ExecutionType.Write, includeParameters, captureReturn: true);
+    }
+
+    public string WrapForDeleteWithReturn(bool includeParameters = true)
+    {
+        return WrapForStoredProc(ExecutionType.Write, includeParameters, captureReturn: true);
+    }
+
 
     public string WrapObjectName(string objectName)
     {

--- a/pengdows.crud/TransactionContext.cs
+++ b/pengdows.crud/TransactionContext.cs
@@ -103,6 +103,7 @@ public class TransactionContext : SafeAsyncDisposableBase, ITransactionContext
     public bool IsReadOnlyConnection => _context.IsReadOnlyConnection;
     public bool RCSIEnabled => _context.RCSIEnabled;
     public int MaxParameterLimit => _context.MaxParameterLimit;
+    public int MaxOutputParameters => _context.MaxOutputParameters;
     public DbMode ConnectionMode => DbMode.SingleConnection;
     public ITypeMapRegistry TypeMapRegistry => _context.TypeMapRegistry;
     public IDataSourceInformation DataSourceInfo => _context.DataSourceInfo;

--- a/pengdows.crud/TransactionContext.cs
+++ b/pengdows.crud/TransactionContext.cs
@@ -122,14 +122,16 @@ public class TransactionContext : SafeAsyncDisposableBase, ITransactionContext
         return new SqlContainer(this, query);
     }
 
-    public DbParameter CreateDbParameter<T>(string name, DbType type, T value)
+    public DbParameter CreateDbParameter<T>(string name, DbType type, T value,
+        ParameterDirection direction = ParameterDirection.Input)
     {
-        return _context.CreateDbParameter(name, type, value);
+        return _context.CreateDbParameter(name, type, value, direction);
     }
 
-    public DbParameter CreateDbParameter<T>(DbType type, T value)
+    public DbParameter CreateDbParameter<T>(DbType type, T value,
+        ParameterDirection direction = ParameterDirection.Input)
     {
-        return _context.CreateDbParameter(type, value);
+        return _context.CreateDbParameter(type, value, direction);
     }
 
     public ITrackedConnection GetConnection(ExecutionType type, bool isShared = false)

--- a/pengdows.crud/TypeMapRegistry.cs
+++ b/pengdows.crud/TypeMapRegistry.cs
@@ -12,7 +12,14 @@ namespace pengdows.crud;
 
 public class TypeMapRegistry : ITypeMapRegistry
 {
+    public static TypeMapRegistry StaticInstance { get; private set; } = new();
+
     private readonly ConcurrentDictionary<Type, TableInfo> _typeMap = new();
+
+    public TypeMapRegistry()
+    {
+        StaticInstance = this;
+    }
 
     public ITableInfo GetTableInfo<T>()
     {

--- a/testbed/TestProvider.cs
+++ b/testbed/TestProvider.cs
@@ -1,6 +1,7 @@
 #region
 
 using pengdows.crud;
+using pengdows.crud.enums;
 
 #endregion
 
@@ -178,7 +179,10 @@ CREATE TABLE {0}test_table{1} (
         var ctx = db ?? _context;
         var sc = _helper.BuildDelete(t.Id, ctx);
         var count = await sc.ExecuteNonQueryAsync();
-        if (count != 1) throw new Exception("Delete failed");
+        if (count != 1)
+        {
+            throw new Exception("Delete failed");
+        }
     }
 
     private async Task TestStoredProcReturnValue()
@@ -186,7 +190,7 @@ CREATE TABLE {0}test_table{1} (
         var sc = _context.CreateSqlContainer();
         switch (_context.Product)
         {
-            case DatabaseProduct.SqlServer:
+            case SupportedDatabase.SqlServer:
                 sc.Query.Append(
                     "CREATE OR ALTER PROCEDURE dbo.ReturnFive AS BEGIN RETURN 5 END");
                 await sc.ExecuteNonQueryAsync();


### PR DESCRIPTION
## Summary
- add CachedSqlTemplates lazy cache in `EntityHelper`
- generate INSERT, UPDATE, and DELETE templates once
- refactor `BuildCreate`, `BuildUpdateAsync`, and `BuildDelete` to use the cache
- add tests verifying cached template reuse for create and update
- reduce helper method parameter counts for update logic
- ensure insert statements use deterministic parameter names and add negative coverage for missing IDs
- surface `MaxOutputParameters` in `DataSourceInformation` to expose per-database limits
- strip existing parameter prefixes before applying database marker and test name handling
- skip non-insertable and non-updateable columns and add targeted tests
- avoid replacing parameter prefixes unless necessary
- enforce output parameter limits when adding parameters and expose these limits via `IDatabaseContext`
- test output parameter limit enforcement and new context property

## Testing
- `apt-get update` *(failed: repository not signed / 403)*
- `apt-get install -y dotnet-sdk-7.0` *(package not found)*
- `dotnet test --no-build` *(command not found: dotnet)*


------
https://chatgpt.com/codex/tasks/task_e_688d5c3b8b8c83258f5fb400e9c87b9a