### PR TITLE
Handle null DataSourceInfo product

### DIFF
--- a/pengdows.crud.Tests/DatabaseContextTests.cs
+++ b/pengdows.crud.Tests/DatabaseContextTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Runtime.Serialization;
 using Moq;
 using pengdows.crud.configuration;
 using pengdows.crud.enums;
@@ -307,5 +308,23 @@ public class DatabaseContextTests
         var context = new DatabaseContext($"Data Source=test;EmulatedProduct={product}", factory);
 
         Assert.Equal(context.DataSourceInfo.MaxOutputParameters, context.MaxOutputParameters);
+    }
+
+    [Fact]
+    public void Product_WhenInitialized_ReturnsProvidedProduct()
+    {
+        var product = SupportedDatabase.SqlServer;
+        var factory = new FakeDbFactory(product);
+        var context = new DatabaseContext($"Data Source=test;EmulatedProduct={product}", factory);
+
+        Assert.Equal(product, context.Product);
+    }
+
+    [Fact]
+    public void Product_WithoutDataSourceInfo_ReturnsUnknown()
+    {
+        var context = (DatabaseContext)FormatterServices.GetUninitializedObject(typeof(DatabaseContext));
+
+        Assert.Equal(SupportedDatabase.Unknown, context.Product);
     }
 }

--- a/pengdows.crud/DatabaseContext.cs
+++ b/pengdows.crud/DatabaseContext.cs
@@ -186,7 +186,13 @@ public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext
 
 
     public string CompositeIdentifierSeparator => _dataSourceInfo.CompositeIdentifierSeparator;
-    public SupportedDatabase Product => _dataSourceInfo.Product;
+    public SupportedDatabase Product
+    {
+        get
+        {
+            return _dataSourceInfo?.Product ?? SupportedDatabase.Unknown;
+        }
+    }
 
     public ISqlContainer CreateSqlContainer(string? query = null)
     {
@@ -544,7 +550,11 @@ public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext
                 ApplyConnectionSessionSettings(conn);
                 _connection = conn;
             }
-            _isolationResolver ??= new IsolationResolver(Product, RCSIEnabled);
+
+            if (_dataSourceInfo != null && _dataSourceInfo.Product != SupportedDatabase.Unknown)
+            {
+                _isolationResolver ??= new IsolationResolver(Product, RCSIEnabled);
+            }
         }
         catch(Exception ex){
             _logger.LogError(ex, ex.Message);
@@ -552,10 +562,16 @@ public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext
         }
         finally
         {
-            _isolationResolver ??= new IsolationResolver(Product, RCSIEnabled);
+            if (_dataSourceInfo != null && _dataSourceInfo.Product != SupportedDatabase.Unknown)
+            {
+                _isolationResolver ??= new IsolationResolver(Product, RCSIEnabled);
+            }
+
             if (mode == DbMode.Standard)
+            {
                 //if it is standard mode, we can close it.
                 conn?.Dispose();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Guard DatabaseContext.Product to safely handle missing DataSourceInfo
- Avoid creating IsolationResolver when DataSourceInfo is absent or unknown
- Add tests for DatabaseContext.Product positive and negative scenarios

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68949108b0b083259195b86827dd1b55