### PR TITLE
Handle unknown database isolation

### DIFF
--- a/pengdows.crud.Tests/DatabaseContextIsolationTests.cs
+++ b/pengdows.crud.Tests/DatabaseContextIsolationTests.cs
@@ -45,4 +45,13 @@ public class DatabaseContextIsolationTests
             new FakeDbFactory(SupportedDatabase.CockroachDb.ToString()));
         Assert.Throws<NotSupportedException>(() => context.BeginTransaction(IsolationProfile.FastWithRisks));
     }
+
+    [Fact]
+    public void BeginTransaction_UnknownProduct_Throws()
+    {
+        var context = new DatabaseContext($"Data Source=test;EmulatedProduct={SupportedDatabase.Unknown}",
+            new FakeDbFactory(SupportedDatabase.Unknown.ToString()));
+
+        Assert.Throws<NotSupportedException>(() => context.BeginTransaction(IsolationProfile.StrictConsistency));
+    }
 }


### PR DESCRIPTION
## Summary
- guard DatabaseContext against unknown databases by skipping isolation resolver initialization
- return SupportedDatabase.Unknown when data source info is missing
- add isolation profile test for unknown database scenarios

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6894911e64ac83259d7061b230d63e02