### PR TITLE
Add positive tests for primary key clause

### DIFF
--- a/pengdows.crud.Tests/EntityHelperBuildWhereByPrimaryKeyTests.cs
+++ b/pengdows.crud.Tests/EntityHelperBuildWhereByPrimaryKeyTests.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace pengdows.crud.Tests;
+
+public class EntityHelperBuildWhereByPrimaryKeyTests : SqlLiteContextTestBase
+{
+    private readonly EntityHelper<TestEntity, int> _helper;
+
+    public EntityHelperBuildWhereByPrimaryKeyTests()
+    {
+        TypeMap.Register<TestEntity>();
+        _helper = new EntityHelper<TestEntity, int>(Context);
+    }
+
+    [Fact]
+    public void BuildWhereByPrimaryKey_GeneratesExpectedWhereClause()
+    {
+        var sc = Context.CreateSqlContainer();
+        var list = new List<TestEntity>
+        {
+            new() { Name = "A" },
+            new() { Name = "B" }
+        };
+
+        _helper.BuildWhereByPrimaryKey(list, sc, "t");
+        var sql = sc.Query.ToString();
+
+        var pattern = "\\n WHERE \\(t\\.\"Name\" = @\\w+\\) OR \\(t\\.\"Name\" = @\\w+\\)";
+        Assert.Matches(pattern, sql);
+        Assert.Equal(2, sc.ParameterCount);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a unit test ensuring `BuildWhereByPrimaryKey` composes a correct WHERE clause with table aliases

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689491316cac8325a84e1b451c03b3e5