### PR TITLE
fix: make locker disposal atomic

### DIFF
--- a/pengdows.crud.Tests/threading/RealAsyncLockerTests.cs
+++ b/pengdows.crud.Tests/threading/RealAsyncLockerTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using pengdows.crud.threading;
+using Xunit;
+
+namespace pengdows.crud.Tests.threading;
+
+public class RealAsyncLockerTests
+{
+    [Fact]
+    public async Task LockAsync_WaitsForRelease()
+    {
+        var semaphore = new SemaphoreSlim(1, 1);
+        var first = new RealAsyncLocker(semaphore);
+        await first.LockAsync().ConfigureAwait(false);
+
+        var acquired = false;
+        var second = new RealAsyncLocker(semaphore);
+        var task = Task.Run(async () =>
+        {
+            await second.LockAsync().ConfigureAwait(false);
+            acquired = true;
+        });
+
+        await Task.Delay(100).ConfigureAwait(false);
+        Assert.False(acquired);
+
+        await first.DisposeAsync().ConfigureAwait(false);
+        await task.ConfigureAwait(false);
+        Assert.True(acquired);
+        await second.DisposeAsync().ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task LockAsync_Cancelled_Throws()
+    {
+        var semaphore = new SemaphoreSlim(1, 1);
+        await semaphore.WaitAsync().ConfigureAwait(false);
+        var locker = new RealAsyncLocker(semaphore);
+        using var cts = new CancellationTokenSource(50);
+        await Assert.ThrowsAsync<OperationCanceledException>(() => locker.LockAsync(cts.Token)).ConfigureAwait(false);
+        semaphore.Release();
+    }
+
+    [Fact]
+    public async Task TryLockAsync_SucceedsWhenAvailable()
+    {
+        var semaphore = new SemaphoreSlim(1, 1);
+        var locker = new RealAsyncLocker(semaphore);
+        var result = await locker.TryLockAsync(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
+        Assert.True(result);
+        await locker.DisposeAsync().ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task TryLockAsync_Timeout_ReturnsFalse()
+    {
+        var semaphore = new SemaphoreSlim(1, 1);
+        var first = new RealAsyncLocker(semaphore);
+        await first.LockAsync().ConfigureAwait(false);
+        var second = new RealAsyncLocker(semaphore);
+        var result = await second.TryLockAsync(TimeSpan.FromMilliseconds(50)).ConfigureAwait(false);
+        Assert.False(result);
+        await second.DisposeAsync().ConfigureAwait(false);
+        await first.DisposeAsync().ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_WithoutLock_IsNoOp()
+    {
+        var semaphore = new SemaphoreSlim(1, 1);
+        var locker = new RealAsyncLocker(semaphore);
+        await locker.DisposeAsync().ConfigureAwait(false);
+        Assert.Equal(1, semaphore.CurrentCount);
+    }
+
+    [Fact]
+    public async Task TryLockAsync_Cancelled_Throws()
+    {
+        var semaphore = new SemaphoreSlim(1, 1);
+        await semaphore.WaitAsync().ConfigureAwait(false);
+        var locker = new RealAsyncLocker(semaphore);
+        using var cts = new CancellationTokenSource(50);
+        await Assert.ThrowsAsync<OperationCanceledException>(() => locker.TryLockAsync(TimeSpan.FromSeconds(1), cts.Token)).ConfigureAwait(false);
+        semaphore.Release();
+    }
+
+    [Fact]
+    public async Task DisposeAsync_DoubleDispose_IsIdempotent()
+    {
+        var semaphore = new SemaphoreSlim(1, 1);
+        var locker = new RealAsyncLocker(semaphore);
+
+        await locker.LockAsync().ConfigureAwait(false);
+        await locker.DisposeAsync().ConfigureAwait(false);
+        await locker.DisposeAsync().ConfigureAwait(false);
+
+        Assert.Equal(1, semaphore.CurrentCount);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_PreventsReuse()
+    {
+        var semaphore = new SemaphoreSlim(1, 1);
+        var locker = new RealAsyncLocker(semaphore);
+
+        await locker.LockAsync().ConfigureAwait(false);
+        await locker.DisposeAsync().ConfigureAwait(false);
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => locker.LockAsync()).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_ConcurrentCalls_ReleaseOnce()
+    {
+        var semaphore = new SemaphoreSlim(1, 1);
+        var locker = new RealAsyncLocker(semaphore);
+
+        await locker.LockAsync().ConfigureAwait(false);
+
+        await Task.WhenAll(
+            locker.DisposeAsync().AsTask(),
+            locker.DisposeAsync().AsTask()).ConfigureAwait(false);
+
+        Assert.Equal(1, semaphore.CurrentCount);
+    }
+}
+

--- a/pengdows.crud.abstractions/threading/ILockerAsync.cs
+++ b/pengdows.crud.abstractions/threading/ILockerAsync.cs
@@ -1,6 +1,11 @@
+using System;
+using System.Threading;
+
 namespace pengdows.crud.threading;
 
 public interface ILockerAsync : IAsyncDisposable
 {
-    Task LockAsync();
+    Task LockAsync(CancellationToken cancellationToken = default);
+
+    Task<bool> TryLockAsync(TimeSpan timeout, CancellationToken cancellationToken = default);
 }

--- a/pengdows.crud/threading/NoOpAsyncLocker.cs
+++ b/pengdows.crud/threading/NoOpAsyncLocker.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace pengdows.crud.threading;
 
 internal sealed class NoOpAsyncLocker : ILockerAsync
@@ -8,9 +12,14 @@ internal sealed class NoOpAsyncLocker : ILockerAsync
     {
     }
 
-    public Task LockAsync()
+    public Task LockAsync(CancellationToken cancellationToken = default)
     {
         return Task.CompletedTask;
+    }
+
+    public Task<bool> TryLockAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(true);
     }
 
     public ValueTask DisposeAsync()

--- a/pengdows.crud/threading/RealAsyncLocker.cs
+++ b/pengdows.crud/threading/RealAsyncLocker.cs
@@ -1,33 +1,70 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using pengdows.crud.infrastructure;
+
 namespace pengdows.crud.threading;
 
-internal sealed class RealAsyncLocker : ILockerAsync
+internal sealed class RealAsyncLocker : SafeAsyncDisposableBase, ILockerAsync
 {
     private readonly SemaphoreSlim _semaphore;
-    private int _disposed;
-    private bool _locked = false;
+    private readonly ILogger<RealAsyncLocker> _logger;
+    private int _lockState;
 
-    public RealAsyncLocker(SemaphoreSlim semaphore)
+    public RealAsyncLocker(SemaphoreSlim semaphore, ILogger<RealAsyncLocker>? logger = null)
     {
-        _semaphore = semaphore;
+        _semaphore = semaphore ?? throw new ArgumentNullException(nameof(semaphore));
+        _logger = logger ?? NullLogger<RealAsyncLocker>.Instance;
     }
 
-    public async Task LockAsync()
+    public async Task LockAsync(CancellationToken cancellationToken = default)
     {
-        //Console.WriteLine("Acquiring lock...");
-        await _semaphore.WaitAsync().ConfigureAwait(false);
-        _locked = true;
-    }
-
-    public ValueTask DisposeAsync()
-    {
-        //Console.WriteLine("Disposing real-async-locker");
-        if (Interlocked.Exchange(ref _disposed, 1) == 0)
+        ThrowIfDisposed();
+        _logger.LogTrace("Waiting for lock");
+        await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        if (Interlocked.CompareExchange(ref _lockState, 1, 0) != 0)
         {
-            if (!_locked) throw new InvalidOperationException("Lock has not been acquired.");
-
             _semaphore.Release();
+            throw new InvalidOperationException("Lock already acquired.");
+        }
+
+        _logger.LogTrace("Lock acquired");
+    }
+
+    public async Task<bool> TryLockAsync(TimeSpan timeout, CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        _logger.LogTrace("Attempting lock with timeout {Timeout}", timeout);
+        var acquired = await _semaphore.WaitAsync(timeout, cancellationToken).ConfigureAwait(false);
+        if (acquired)
+        {
+            if (Interlocked.CompareExchange(ref _lockState, 1, 0) != 0)
+            {
+                _semaphore.Release();
+                throw new InvalidOperationException("Lock already acquired.");
+            }
+
+            _logger.LogTrace("Lock acquired");
+        }
+        else
+        {
+            _logger.LogTrace("Lock acquisition timed out");
+        }
+
+        return acquired;
+    }
+
+    protected override ValueTask DisposeManagedAsync()
+    {
+        if (Interlocked.CompareExchange(ref _lockState, 0, 1) == 1)
+        {
+            _semaphore.Release();
+            _logger.LogTrace("Lock released");
         }
 
         return ValueTask.CompletedTask;
     }
 }
+


### PR DESCRIPTION
## Summary
- make `RealAsyncLocker` derive from `SafeAsyncDisposableBase` to handle disposal atomically
- keep tests covering double and concurrent dispose

## Testing
- `dotnet test` *(fails: command not found: dotnet)*
- `apt-get update` *(403  Forbidden [IP: 172.30.0.35 8080])*

------
https://chatgpt.com/codex/tasks/task_e_689bb51c2a308325abdae8e1da7c822e