### PR TITLE
Fix SqlDialect test DataSourceInformation usage

### DIFF
--- a/pengdows.crud.Tests/SqlDialectTests.cs
+++ b/pengdows.crud.Tests/SqlDialectTests.cs
@@ -52,8 +52,11 @@ public class SqlDialectTests
     public void CreateDbParameter_SetsProperties()
     {
         var factory = new FakeDbFactory(SupportedDatabase.Sqlite);
-        var info =new DataSourceInformation( DataSourceInformation.BuildEmptySchema("SQLite", "1", "?", "?", 64, "\\w+", "\\w+", true));
-        var dialect = new SqlDialect(info, factory, (lenth, max) => "p");
+        var schema = DataSourceInformation.BuildEmptySchema("SQLite", "1", "?", "?", 64, "\\w+", "\\w+", true);
+        var conn = (FakeDbConnection)factory.CreateConnection();
+        var tracked = new FakeTrackedConnection(conn, schema, new Dictionary<string, object>());
+        var info = DataSourceInformation.Create(tracked);
+        var dialect = new SqlDialect(info, factory, (length, max) => "p");
         var p = dialect.CreateDbParameter("p", DbType.Int32, 1);
         Assert.Equal("p", p.ParameterName);
         Assert.Equal(DbType.Int32, p.DbType);


### PR DESCRIPTION
## Summary
- fix SqlDialect CreateDbParameter test to construct DataSourceInformation from a tracked connection

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68a099843b34832580f0a80a8c358257