### PR TITLE
Fix SpyDatabaseContext dialect interface and add tests

### DIFF
--- a/pengdows.crud.Tests/Mocks/SpyDatabaseContext.cs
+++ b/pengdows.crud.Tests/Mocks/SpyDatabaseContext.cs
@@ -10,7 +10,7 @@ using pengdows.crud.wrappers;
 
 namespace pengdows.crud.Tests.Mocks;
 
-public sealed class SpyDatabaseContext : IDatabaseContext, IContextIdentity
+public sealed class SpyDatabaseContext : IDatabaseContext, IContextIdentity, ISqlDialectProvider
 {
     private readonly IDatabaseContext _inner;
 
@@ -102,4 +102,6 @@ public sealed class SpyDatabaseContext : IDatabaseContext, IContextIdentity
     public void Dispose() => _inner.Dispose();
 
     public ValueTask DisposeAsync() => _inner.DisposeAsync();
+
+    SqlDialect ISqlDialectProvider.Dialect => ((ISqlDialectProvider)_inner).Dialect;
 }

--- a/pengdows.crud.Tests/SpyDatabaseContextTests.cs
+++ b/pengdows.crud.Tests/SpyDatabaseContextTests.cs
@@ -1,0 +1,32 @@
+using System;
+using Moq;
+using pengdows.crud;
+using pengdows.crud.Tests.Mocks;
+using Xunit;
+
+namespace pengdows.crud.Tests;
+
+public class SpyDatabaseContextTests : SqlLiteContextTestBase
+{
+    [Fact]
+    public void Dialect_DelegatesToInnerContext()
+    {
+        var spy = new SpyDatabaseContext(Context);
+        var expected = ((ISqlDialectProvider)Context).Dialect;
+        var actual = ((ISqlDialectProvider)spy).Dialect;
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void EntityHelper_WithContextMissingDialectProvider_Throws()
+    {
+        var map = new TypeMapRegistry();
+        map.Register<NullableIdEntity>();
+
+        var mockCtx = new Mock<IDatabaseContext>();
+        mockCtx.SetupGet(c => c.TypeMapRegistry).Returns(map);
+        mockCtx.As<IContextIdentity>().SetupGet(i => i.RootId).Returns(Guid.NewGuid());
+
+        Assert.Throws<InvalidCastException>(() => new EntityHelper<NullableIdEntity, int?>(mockCtx.Object));
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `ISqlDialectProvider` in `SpyDatabaseContext` to delegate dialect from inner context
- Add positive and negative tests covering `SpyDatabaseContext` dialect behavior

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a09d44cf1c83259f8cc83effbebb24