### PR TITLE
Honor schema parameter markers

### DIFF
--- a/pengdows.crud.Tests/Mocks/SpyDatabaseContext.cs
+++ b/pengdows.crud.Tests/Mocks/SpyDatabaseContext.cs
@@ -65,7 +65,10 @@ public sealed class SpyDatabaseContext : IDatabaseContext, IContextIdentity, ISq
 
     public ILockerAsync GetLock() => _inner.GetLock();
 
-    public ISqlContainer CreateSqlContainer(string? query = null) => _inner.CreateSqlContainer(query);
+    public ISqlContainer CreateSqlContainer(string? query = null)
+    {
+        return new SqlContainer(this, ((ISqlDialectProvider)_inner).Dialect, query);
+    }
 
     public DbParameter CreateDbParameter<T>(string? name, DbType type, T value)
     {

--- a/pengdows.crud/DataSourceInformation.cs
+++ b/pengdows.crud/DataSourceInformation.cs
@@ -236,7 +236,16 @@ public class DataSourceInformation : IDataSourceInformation
         ParameterMarkerPattern = GetField<string>(row, "ParameterMarkerPattern", string.Empty);
         ParameterNameMaxLength = GetField<int>(row, "ParameterNameMaxLength", 0);
         SupportsNamedParameters = GetField<bool>(row, "SupportsNamedParameters", false);
-        ParameterMarker = DefaultMarkers.GetValueOrDefault(Product, "?");
+        var markerFormat = GetField<string>(row, "ParameterMarkerFormat", string.Empty);
+        if (!string.IsNullOrWhiteSpace(markerFormat))
+        {
+            ParameterMarker = markerFormat.Replace("{0}", string.Empty);
+        }
+        else
+        {
+            ParameterMarker = DefaultMarkers.GetValueOrDefault(Product, "?");
+        }
+
         SupportsNamedParameters |= ParameterMarker != "?";
         ProcWrappingStyle = ProcWrapStyles.GetValueOrDefault(Product, ProcWrappingStyle.None);
         MaxParameterLimit = MaxParameterLimits.GetValueOrDefault(Product, 999);


### PR DESCRIPTION
## Summary
- respect schema-defined parameter markers when building data source info
- ensure SpyDatabaseContext uses itself to create containers for proper call tracking

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b21dd4bc8325b260c6d8ecaa574b