### PR TITLE
Add SQL dialect factory and implementations

### DIFF
--- a/pengdows.crud.Tests/SqlDialectFactoryTests.cs
+++ b/pengdows.crud.Tests/SqlDialectFactoryTests.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using pengdows.crud.enums;
+using pengdows.crud.FakeDb;
+using pengdows.crud.dialects;
+using Xunit;
+
+namespace pengdows.crud.Tests;
+
+public class SqlDialectFactoryTests
+{
+    [Fact]
+    public void CreateDialectForType_SqlServer_ReturnsSqlServerDialect()
+    {
+        var factory = new FakeDbFactory(SupportedDatabase.SqlServer);
+        var dialect = SqlDialectFactory.CreateDialectForType(
+            SupportedDatabase.SqlServer,
+            factory,
+            (length, max) => "p",
+            NullLoggerFactory.Instance.CreateLogger<SqlDialect>());
+        Assert.IsType<SqlServerDialect>(dialect);
+    }
+
+    [Fact]
+    public void CreateDialectForType_Firebird_ThrowsNotImplementedException()
+    {
+        var factory = new FakeDbFactory(SupportedDatabase.Firebird);
+        Assert.Throws<NotImplementedException>(() =>
+            SqlDialectFactory.CreateDialectForType(
+                SupportedDatabase.Firebird,
+                factory,
+                (length, max) => "p",
+                NullLoggerFactory.Instance.CreateLogger<SqlDialect>()));
+    }
+}

--- a/pengdows.crud.Tests/SqlDialectFeatureTests.cs
+++ b/pengdows.crud.Tests/SqlDialectFeatureTests.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using pengdows.crud.enums;
+using pengdows.crud.FakeDb;
+using pengdows.crud.dialects;
+using Xunit;
+
+namespace pengdows.crud.Tests;
+
+public class SqlDialectFeatureTests
+{
+    [Fact]
+    public async Task SupportsJsonTypes_SqlServer2019_ReturnsTrue()
+    {
+        var schema = DataSourceInformation.BuildEmptySchema(
+            "Microsoft SQL Server",
+            "15.0",
+            "@[0-9]+",
+            "@{0}",
+            64,
+            @"@\w+",
+            @"@\w+",
+            true);
+        var scalars = new Dictionary<string, object>
+        {
+            ["SELECT @@VERSION"] = "Microsoft SQL Server 15.0"
+        };
+        var factory = new FakeDbFactory(SupportedDatabase.SqlServer);
+        var conn = (FakeDbConnection)factory.CreateConnection();
+        conn.ConnectionString = $"Data Source=test;EmulatedProduct={SupportedDatabase.SqlServer}";
+        var tracked = new FakeTrackedConnection(conn, schema, scalars);
+        var dialect = SqlDialectFactory.CreateDialectForType(
+            SupportedDatabase.SqlServer,
+            factory,
+            (length, max) => "p",
+            NullLoggerFactory.Instance.CreateLogger<SqlDialect>());
+        await dialect.DetectDatabaseInfoAsync(tracked);
+        Assert.True(dialect.SupportsJsonTypes);
+    }
+
+    [Fact]
+    public async Task SupportsJsonTypes_OldSqlServer_ReturnsFalse()
+    {
+        var schema = DataSourceInformation.BuildEmptySchema(
+            "Microsoft SQL Server",
+            "8.0",
+            "@[0-9]+",
+            "@{0}",
+            64,
+            @"@\w+",
+            @"@\w+",
+            true);
+        var scalars = new Dictionary<string, object>
+        {
+            ["SELECT @@VERSION"] = "Microsoft SQL Server 8.0"
+        };
+        var factory = new FakeDbFactory(SupportedDatabase.SqlServer);
+        var conn = (FakeDbConnection)factory.CreateConnection();
+        conn.ConnectionString = $"Data Source=test;EmulatedProduct={SupportedDatabase.SqlServer}";
+        var tracked = new FakeTrackedConnection(conn, schema, scalars);
+        var dialect = SqlDialectFactory.CreateDialectForType(
+            SupportedDatabase.SqlServer,
+            factory,
+            (length, max) => "p",
+            NullLoggerFactory.Instance.CreateLogger<SqlDialect>());
+        await dialect.DetectDatabaseInfoAsync(tracked);
+        Assert.False(dialect.SupportsJsonTypes);
+    }
+}

--- a/pengdows.crud.Tests/SqlStandardLevelTests.cs
+++ b/pengdows.crud.Tests/SqlStandardLevelTests.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using pengdows.crud.enums;
+using pengdows.crud.FakeDb;
+using pengdows.crud.wrappers;
+using Xunit;
+
+namespace pengdows.crud.Tests;
+
+public class SqlStandardLevelTests
+{
+    [Fact]
+    public void StandardCompliance_SqlServer2019_ReturnsSql2016()
+    {
+        var schema = DataSourceInformation.BuildEmptySchema(
+            "Microsoft SQL Server",
+            "15.0",
+            "@[0-9]+",
+            "@{0}",
+            64,
+            @"@\w+",
+            @"@\w+",
+            true);
+        var scalars = new Dictionary<string, object>
+        {
+            ["SELECT @@VERSION"] = "Microsoft SQL Server 15.0"
+        };
+        var factory = new FakeDbFactory(SupportedDatabase.SqlServer);
+        var conn = (FakeDbConnection)factory.CreateConnection();
+        conn.ConnectionString = $"Data Source=test;EmulatedProduct={SupportedDatabase.SqlServer}";
+        var tracked = new FakeTrackedConnection(conn, schema, scalars);
+        var info = DataSourceInformation.Create(tracked);
+        Assert.Equal(SqlStandardLevel.Sql2016, info.StandardCompliance);
+    }
+
+    [Fact]
+    public void StandardCompliance_OldSqlServer_ReturnsSql2003()
+    {
+        var schema = DataSourceInformation.BuildEmptySchema(
+            "Microsoft SQL Server",
+            "8.0",
+            "@[0-9]+",
+            "@{0}",
+            64,
+            @"@\w+",
+            @"@\w+",
+            true);
+        var scalars = new Dictionary<string, object>
+        {
+            ["SELECT @@VERSION"] = "Microsoft SQL Server 8.0"
+        };
+        var factory = new FakeDbFactory(SupportedDatabase.SqlServer);
+        var conn = (FakeDbConnection)factory.CreateConnection();
+        conn.ConnectionString = $"Data Source=test;EmulatedProduct={SupportedDatabase.SqlServer}";
+        var tracked = new FakeTrackedConnection(conn, schema, scalars);
+        var info = DataSourceInformation.Create(tracked);
+        Assert.Equal(SqlStandardLevel.Sql2003, info.StandardCompliance);
+    }
+}

--- a/pengdows.crud.abstractions/IDataSourceInformation.cs
+++ b/pengdows.crud.abstractions/IDataSourceInformation.cs
@@ -101,6 +101,11 @@ public interface IDataSourceInformation
     bool RequiresStoredProcParameterNameMatch { get; }
 
     /// <summary>
+    /// Gets the SQL standard compliance level for the detected database.
+    /// </summary>
+    SqlStandardLevel StandardCompliance { get; }
+
+    /// <summary>
     /// Retrieves the raw database version string from the specified connection.
     /// </summary>
     /// <param name="connection">The connection to query.</param>

--- a/pengdows.crud.abstractions/enums/SqlStandardLevel.cs
+++ b/pengdows.crud.abstractions/enums/SqlStandardLevel.cs
@@ -1,0 +1,19 @@
+namespace pengdows.crud.enums;
+
+/// <summary>
+/// SQL standard compliance levels
+/// </summary>
+public enum SqlStandardLevel
+{
+    Sql86 = 1986,
+    Sql89 = 1989,
+    Sql92 = 1992,
+    Sql99 = 1999,
+    Sql2003 = 2003,
+    Sql2006 = 2006,
+    Sql2008 = 2008,
+    Sql2011 = 2011,
+    Sql2016 = 2016,
+    Sql2019 = 2019,
+    Sql2023 = 2023
+}

--- a/pengdows.crud/SqlDialect.cs
+++ b/pengdows.crud/SqlDialect.cs
@@ -4,6 +4,7 @@ using System;
 using System.Data;
 using System.Data.Common;
 using System.Text;
+using pengdows.crud.enums;
 
 /// <summary>
 /// Provides database-dialect-specific helpers for building SQL.
@@ -26,6 +27,31 @@ internal sealed class SqlDialect
     internal string CompositeIdentifierSeparator => _info.CompositeIdentifierSeparator;
     
     internal int ParameterNameMaxLength => _info.ParameterNameMaxLength;
+    internal SqlStandardLevel StandardCompliance => _info.StandardCompliance;
+
+    internal bool SupportsIntegrityConstraints => StandardCompliance >= SqlStandardLevel.Sql89;
+    internal bool SupportsJoins => StandardCompliance >= SqlStandardLevel.Sql92;
+    internal bool SupportsOuterJoins => StandardCompliance >= SqlStandardLevel.Sql92;
+    internal bool SupportsSubqueries => StandardCompliance >= SqlStandardLevel.Sql92;
+    internal bool SupportsUnion => StandardCompliance >= SqlStandardLevel.Sql92;
+    internal bool SupportsUserDefinedTypes => StandardCompliance >= SqlStandardLevel.Sql99;
+    internal bool SupportsArrayTypes => StandardCompliance >= SqlStandardLevel.Sql99;
+    internal bool SupportsRegularExpressions => StandardCompliance >= SqlStandardLevel.Sql99;
+    internal bool SupportsMerge => StandardCompliance >= SqlStandardLevel.Sql2003;
+    internal bool SupportsXmlTypes => StandardCompliance >= SqlStandardLevel.Sql2003;
+    internal bool SupportsWindowFunctions => StandardCompliance >= SqlStandardLevel.Sql2003;
+    internal bool SupportsCommonTableExpressions => StandardCompliance >= SqlStandardLevel.Sql2003;
+    internal bool SupportsInsteadOfTriggers => StandardCompliance >= SqlStandardLevel.Sql2008;
+    internal bool SupportsTruncateTable => StandardCompliance >= SqlStandardLevel.Sql2008;
+    internal bool SupportsTemporalData => StandardCompliance >= SqlStandardLevel.Sql2011;
+    internal bool SupportsEnhancedWindowFunctions => StandardCompliance >= SqlStandardLevel.Sql2011;
+    internal bool SupportsJsonTypes => StandardCompliance >= SqlStandardLevel.Sql2016;
+    internal bool SupportsRowPatternMatching => StandardCompliance >= SqlStandardLevel.Sql2016;
+    internal bool SupportsMultidimensionalArrays => StandardCompliance >= SqlStandardLevel.Sql2019;
+    internal bool SupportsPropertyGraphQueries => StandardCompliance >= SqlStandardLevel.Sql2023;
+    internal virtual bool SupportsInsertOnConflict => false;
+    internal virtual bool RequiresStoredProcParameterNameMatch => false;
+    internal virtual bool SupportsNamespaces => true;
 
     internal string WrapObjectName(string name)
     {

--- a/pengdows.crud/dialects/DatabaseProductInfo.cs
+++ b/pengdows.crud/dialects/DatabaseProductInfo.cs
@@ -1,0 +1,15 @@
+using pengdows.crud.enums;
+
+namespace pengdows.crud.dialects;
+
+/// <summary>
+/// Contains database product information detected from the connection
+/// </summary>
+public class DatabaseProductInfo
+{
+    public string ProductName { get; set; } = string.Empty;
+    public string ProductVersion { get; set; } = string.Empty;
+    public Version? ParsedVersion { get; set; }
+    public SupportedDatabase DatabaseType { get; set; }
+    public SqlStandardLevel StandardCompliance { get; set; } = SqlStandardLevel.Sql92;
+}

--- a/pengdows.crud/dialects/MySqlDialect.cs
+++ b/pengdows.crud/dialects/MySqlDialect.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using Microsoft.Extensions.Logging;
+
+namespace pengdows.crud.dialects;
+
+/// <summary>
+/// MySQL dialect with limited standard compliance
+/// </summary>
+public class MySqlDialect : SqlDialect
+{
+    public MySqlDialect(DbProviderFactory factory, Func<int, int, string> nameGenerator, ILogger logger)
+        : base(factory, nameGenerator, logger)
+    {
+    }
+
+    public override SupportedDatabase DatabaseType => SupportedDatabase.MySql;
+    public override string ParameterMarker => "@";
+    public override bool SupportsNamedParameters => true;
+    public override int MaxParameterLimit => 65535;
+    public override int ParameterNameMaxLength => 64;
+    public override ProcWrappingStyle ProcWrappingStyle => ProcWrappingStyle.Call;
+
+    public override string QuotePrefix => "`";
+    public override string QuoteSuffix => "`";
+
+    public override SqlStandardLevel MaxSupportedStandard => SqlStandardLevel.Sql2011;
+
+    public override bool SupportsInsertOnConflict => true;
+    public override bool SupportsMerge => false;
+    public override bool SupportsJsonTypes => IsInitialized && ProductInfo.ParsedVersion?.Major >= 5;
+    public override bool SupportsWindowFunctions => IsInitialized && ProductInfo.ParsedVersion?.Major >= 8;
+    public override bool SupportsCommonTableExpressions => IsInitialized && ProductInfo.ParsedVersion?.Major >= 8;
+
+    public override string GetVersionQuery() => "SELECT VERSION()";
+
+    public override string GetConnectionSessionSettings()
+    {
+        return "SET SESSION sql_mode = 'STRICT_ALL_TABLES,ONLY_FULL_GROUP_BY,NO_ZERO_DATE,NO_ENGINE_SUBSTITUTION,ANSI_QUOTES';";
+    }
+
+    public override void ApplyConnectionSettings(IDbConnection connection)
+    {
+        try
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = GetConnectionSessionSettings();
+            cmd.ExecuteNonQuery();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to apply MySQL connection settings");
+        }
+    }
+
+    protected override SqlStandardLevel DetermineStandardCompliance(Version? version)
+    {
+        if (version == null)
+        {
+            return SqlStandardLevel.Sql92;
+        }
+
+        return version.Major switch
+        {
+            >= 8 => SqlStandardLevel.Sql2008,
+            >= 6 => SqlStandardLevel.Sql2003,
+            >= 5 => SqlStandardLevel.Sql99,
+            _ => SqlStandardLevel.Sql92
+        };
+    }
+}

--- a/pengdows.crud/dialects/OracleDialect.cs
+++ b/pengdows.crud/dialects/OracleDialect.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using Microsoft.Extensions.Logging;
+
+namespace pengdows.crud.dialects;
+
+/// <summary>
+/// Oracle dialect with comprehensive enterprise features
+/// </summary>
+public class OracleDialect : SqlDialect
+{
+    public OracleDialect(DbProviderFactory factory, Func<int, int, string> nameGenerator, ILogger logger)
+        : base(factory, nameGenerator, logger)
+    {
+    }
+
+    public override SupportedDatabase DatabaseType => SupportedDatabase.Oracle;
+    public override string ParameterMarker => ":";
+    public override bool SupportsNamedParameters => true;
+    public override int MaxParameterLimit => 1000;
+    public override int ParameterNameMaxLength => 30;
+    public override ProcWrappingStyle ProcWrappingStyle => ProcWrappingStyle.Oracle;
+    public override bool RequiresStoredProcParameterNameMatch => true;
+
+    public override SqlStandardLevel MaxSupportedStandard => SqlStandardLevel.Sql2016;
+
+    public override bool SupportsMerge => true;
+    public override bool SupportsJsonTypes => IsInitialized && ProductInfo.ParsedVersion?.Major >= 12;
+
+    public override string GetVersionQuery() => "SELECT * FROM v$version WHERE banner LIKE 'Oracle%'";
+
+    public override string GetConnectionSessionSettings()
+    {
+        return "ALTER SESSION SET NLS_DATE_FORMAT = 'YYYY-MM-DD';";
+    }
+
+    public override void ApplyConnectionSettings(IDbConnection connection)
+    {
+        try
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = GetConnectionSessionSettings();
+            cmd.ExecuteNonQuery();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to apply Oracle connection settings");
+        }
+    }
+
+    protected override SqlStandardLevel DetermineStandardCompliance(Version? version)
+    {
+        if (version == null)
+        {
+            return SqlStandardLevel.Sql2003;
+        }
+
+        return version.Major switch
+        {
+            >= 21 => SqlStandardLevel.Sql2016,
+            >= 19 => SqlStandardLevel.Sql2016,
+            >= 18 => SqlStandardLevel.Sql2011,
+            >= 12 => SqlStandardLevel.Sql2008,
+            >= 11 => SqlStandardLevel.Sql2003,
+            _ => SqlStandardLevel.Sql99
+        };
+    }
+}

--- a/pengdows.crud/dialects/PostgreSqlDialect.cs
+++ b/pengdows.crud/dialects/PostgreSqlDialect.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using Microsoft.Extensions.Logging;
+
+namespace pengdows.crud.dialects;
+
+/// <summary>
+/// PostgreSQL dialect with comprehensive standard support
+/// </summary>
+public class PostgreSqlDialect : SqlDialect
+{
+    public PostgreSqlDialect(DbProviderFactory factory, Func<int, int, string> nameGenerator, ILogger logger)
+        : base(factory, nameGenerator, logger)
+    {
+    }
+
+    public override SupportedDatabase DatabaseType => SupportedDatabase.PostgreSql;
+    public override string ParameterMarker => "$";
+    public override bool SupportsNamedParameters => true;
+    public override int MaxParameterLimit => 65535;
+    public override int ParameterNameMaxLength => 63;
+    public override ProcWrappingStyle ProcWrappingStyle => ProcWrappingStyle.PostgreSQL;
+    public override bool RequiresStoredProcParameterNameMatch => true;
+
+    public override SqlStandardLevel MaxSupportedStandard => SqlStandardLevel.Sql2016;
+
+    public override bool SupportsInsertOnConflict => true;
+    public override bool SupportsMerge => IsInitialized && ProductInfo.ParsedVersion?.Major >= 15;
+    public override bool SupportsJsonTypes => IsInitialized && ProductInfo.ParsedVersion?.Major >= 9;
+
+    public override string GetVersionQuery() => "SELECT version()";
+
+    public override string GetConnectionSessionSettings()
+    {
+        return @"SET standard_conforming_strings = on;
+SET client_min_messages = warning;
+SET search_path = public;";
+    }
+
+    public override void ApplyConnectionSettings(IDbConnection connection)
+    {
+        try
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = GetConnectionSessionSettings();
+            cmd.ExecuteNonQuery();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to apply PostgreSQL connection settings");
+        }
+    }
+
+    protected override SqlStandardLevel DetermineStandardCompliance(Version? version)
+    {
+        if (version == null)
+        {
+            return SqlStandardLevel.Sql2008;
+        }
+
+        return version.Major switch
+        {
+            >= 15 => SqlStandardLevel.Sql2016,
+            >= 13 => SqlStandardLevel.Sql2011,
+            >= 11 => SqlStandardLevel.Sql2008,
+            >= 9 => SqlStandardLevel.Sql2003,
+            _ => SqlStandardLevel.Sql92
+        };
+    }
+}

--- a/pengdows.crud/dialects/SqlDialect.cs
+++ b/pengdows.crud/dialects/SqlDialect.cs
@@ -1,0 +1,396 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using pengdows.crud.enums;
+using pengdows.crud.wrappers;
+using pengdows.crud;
+
+namespace pengdows.crud.dialects;
+
+/// <summary>
+/// Base SQL dialect implementing standard SQL behaviors with feature detection
+/// </summary>
+public abstract class SqlDialect
+{
+    protected readonly DbProviderFactory Factory;
+    protected readonly Func<int, int, string> NameGenerator;
+    protected readonly ILogger Logger;
+
+    private DatabaseProductInfo? _productInfo;
+
+    protected SqlDialect(DbProviderFactory factory, Func<int, int, string> nameGenerator, ILogger logger)
+    {
+        Factory = factory ?? throw new ArgumentNullException(nameof(factory));
+        NameGenerator = nameGenerator ?? throw new ArgumentNullException(nameof(nameGenerator));
+        Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Gets the detected database product information. Call DetectDatabaseInfo first.
+    /// </summary>
+    public DatabaseProductInfo ProductInfo => _productInfo ?? throw new InvalidOperationException("Database info not detected. Call DetectDatabaseInfo first.");
+
+    /// <summary>
+    /// Whether database info has been detected
+    /// </summary>
+    public bool IsInitialized => _productInfo != null;
+
+    // Abstract properties that each dialect must define
+    public abstract SupportedDatabase DatabaseType { get; }
+    public abstract string ParameterMarker { get; }
+    public abstract bool SupportsNamedParameters { get; }
+    public abstract int MaxParameterLimit { get; }
+    public abstract int ParameterNameMaxLength { get; }
+    public abstract ProcWrappingStyle ProcWrappingStyle { get; }
+
+    /// <summary>
+    /// The highest SQL standard level this database/version supports
+    /// </summary>
+    public abstract SqlStandardLevel MaxSupportedStandard { get; }
+
+    // SQL standard defaults - can be overridden for database-specific behavior
+    public virtual string QuotePrefix => "\"";  // SQL-92 standard
+    public virtual string QuoteSuffix => "\"";   // SQL-92 standard
+    public virtual string CompositeIdentifierSeparator => "."; // SQL-92 standard
+    public virtual bool PrepareStatements => false;
+
+    // SQL standard parameter name pattern (SQL-92)
+    protected virtual Regex ParameterNamePattern => new("^[a-zA-Z][a-zA-Z0-9_]*$", RegexOptions.Compiled);
+
+    // Feature support based on SQL standards and database capabilities
+    public virtual bool SupportsIntegrityConstraints => MaxSupportedStandard >= SqlStandardLevel.Sql89;
+    public virtual bool SupportsJoins => MaxSupportedStandard >= SqlStandardLevel.Sql92;
+    public virtual bool SupportsOuterJoins => MaxSupportedStandard >= SqlStandardLevel.Sql92;
+    public virtual bool SupportsSubqueries => MaxSupportedStandard >= SqlStandardLevel.Sql92;
+    public virtual bool SupportsUnion => MaxSupportedStandard >= SqlStandardLevel.Sql92;
+
+    // SQL:1999 (SQL3) features
+    public virtual bool SupportsUserDefinedTypes => MaxSupportedStandard >= SqlStandardLevel.Sql99;
+    public virtual bool SupportsArrayTypes => MaxSupportedStandard >= SqlStandardLevel.Sql99;
+    public virtual bool SupportsRegularExpressions => MaxSupportedStandard >= SqlStandardLevel.Sql99;
+
+    // SQL:2003 features
+    public virtual bool SupportsMerge => MaxSupportedStandard >= SqlStandardLevel.Sql2003;
+    public virtual bool SupportsXmlTypes => MaxSupportedStandard >= SqlStandardLevel.Sql2003;
+    public virtual bool SupportsWindowFunctions => MaxSupportedStandard >= SqlStandardLevel.Sql2003;
+    public virtual bool SupportsCommonTableExpressions => MaxSupportedStandard >= SqlStandardLevel.Sql2003;
+
+    // SQL:2008 features
+    public virtual bool SupportsInsteadOfTriggers => MaxSupportedStandard >= SqlStandardLevel.Sql2008;
+    public virtual bool SupportsTruncateTable => MaxSupportedStandard >= SqlStandardLevel.Sql2008;
+
+    // SQL:2011 features
+    public virtual bool SupportsTemporalData => MaxSupportedStandard >= SqlStandardLevel.Sql2011;
+    public virtual bool SupportsEnhancedWindowFunctions => MaxSupportedStandard >= SqlStandardLevel.Sql2011;
+
+    // SQL:2016 features
+    public virtual bool SupportsJsonTypes => MaxSupportedStandard >= SqlStandardLevel.Sql2016;
+    public virtual bool SupportsRowPatternMatching => MaxSupportedStandard >= SqlStandardLevel.Sql2016;
+
+    // SQL:2019 features
+    public virtual bool SupportsMultidimensionalArrays => MaxSupportedStandard >= SqlStandardLevel.Sql2019;
+
+    // SQL:2023 features
+    public virtual bool SupportsPropertyGraphQueries => MaxSupportedStandard >= SqlStandardLevel.Sql2023;
+
+    // Database-specific extensions (override as needed)
+    public virtual bool SupportsInsertOnConflict => false; // PostgreSQL, SQLite extension
+    public virtual bool RequiresStoredProcParameterNameMatch => false;
+    public virtual bool SupportsNamespaces => true; // Most databases support schemas/namespaces, SQLite does not
+
+    public virtual string WrapObjectName(string name)
+    {
+        if (string.IsNullOrEmpty(name?.Trim()))
+        {
+            return string.Empty;
+        }
+
+        var cleaned = name.Replace(QuotePrefix, string.Empty).Replace(QuoteSuffix, string.Empty);
+        var parts = cleaned.Split(CompositeIdentifierSeparator);
+        var sb = new StringBuilder();
+
+        for (var i = 0; i < parts.Length; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(CompositeIdentifierSeparator);
+            }
+
+            sb.Append(QuotePrefix).Append(parts[i]).Append(QuoteSuffix);
+        }
+
+        return sb.ToString();
+    }
+
+    public virtual string MakeParameterName(string parameterName)
+    {
+        if (!SupportsNamedParameters)
+        {
+            return "?";
+        }
+
+        return string.Concat(ParameterMarker, parameterName);
+    }
+
+    public virtual string MakeParameterName(DbParameter dbParameter)
+    {
+        return MakeParameterName(dbParameter.ParameterName);
+    }
+
+    public virtual DbParameter CreateDbParameter<T>(string? name, DbType type, T value)
+    {
+        var p = Factory.CreateParameter() ?? throw new InvalidOperationException("Failed to create parameter.");
+
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            name = NameGenerator(5, ParameterNameMaxLength);
+        }
+
+        var valueIsNull = Utils.IsNullOrDbNull(value);
+        p.ParameterName = name;
+        p.DbType = type;
+        p.Value = valueIsNull ? DBNull.Value : value!;
+
+        if (!valueIsNull && p.DbType == DbType.String && value is string s)
+        {
+            p.Size = Math.Max(s.Length, 1);
+        }
+
+        return p;
+    }
+
+    public virtual DbParameter CreateDbParameter<T>(DbType type, T value)
+    {
+        return CreateDbParameter(null, type, value);
+    }
+
+    // Abstract methods for database-specific operations
+    public abstract string GetVersionQuery();
+    public abstract string GetConnectionSessionSettings();
+    public abstract void ApplyConnectionSettings(IDbConnection connection);
+
+    /// <summary>
+    /// Detects database product information from the connection
+    /// </summary>
+    public virtual async Task<DatabaseProductInfo> DetectDatabaseInfoAsync(ITrackedConnection connection)
+    {
+        if (_productInfo != null)
+        {
+            return _productInfo;
+        }
+
+        try
+        {
+            var versionString = await GetDatabaseVersionAsync(connection);
+            var productName = await GetProductNameAsync(connection) ?? ExtractProductNameFromVersion(versionString);
+            var parsedVersion = ParseVersion(versionString);
+            var databaseType = InferDatabaseTypeFromInfo(productName, versionString);
+            var standardCompliance = DetermineStandardCompliance(parsedVersion);
+
+            _productInfo = new DatabaseProductInfo
+            {
+                ProductName = productName,
+                ProductVersion = versionString,
+                ParsedVersion = parsedVersion,
+                DatabaseType = databaseType,
+                StandardCompliance = standardCompliance
+            };
+
+            Logger.LogInformation("Detected database: {ProductName} {Version} (SQL Standard: {Standard})", productName, versionString, standardCompliance);
+            return _productInfo;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to detect database information");
+
+            _productInfo = new DatabaseProductInfo
+            {
+                ProductName = "Unknown Database",
+                ProductVersion = "Unknown Version",
+                DatabaseType = DatabaseType,
+                StandardCompliance = SqlStandardLevel.Sql92
+            };
+            return _productInfo;
+        }
+    }
+
+    /// <summary>
+    /// Determines SQL standard compliance based on database version
+    /// Override in concrete dialects for database-specific logic
+    /// </summary>
+    protected virtual SqlStandardLevel DetermineStandardCompliance(Version? version)
+    {
+        return MaxSupportedStandard;
+    }
+
+    public DatabaseProductInfo DetectDatabaseInfo(ITrackedConnection connection)
+    {
+        return DetectDatabaseInfoAsync(connection).GetAwaiter().GetResult();
+    }
+
+    protected virtual async Task<string> GetDatabaseVersionAsync(ITrackedConnection connection)
+    {
+        try
+        {
+            var versionQuery = GetVersionQuery();
+            if (string.IsNullOrEmpty(versionQuery))
+            {
+                return "Unknown Version";
+            }
+
+            await using var cmd = (DbCommand)connection.CreateCommand();
+            cmd.CommandText = versionQuery;
+            await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleRow | CommandBehavior.SingleResult);
+
+            if (await reader.ReadAsync())
+            {
+                var result = reader.GetValue(0)?.ToString();
+                return result ?? "Unknown Version";
+            }
+
+            return "Unknown Version";
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Failed to get database version using query: {Query}", GetVersionQuery());
+            return "Error retrieving version: " + ex.Message;
+        }
+    }
+
+    protected virtual async Task<string?> GetProductNameAsync(ITrackedConnection connection)
+    {
+        try
+        {
+            var schema = connection.GetSchema(DbMetaDataCollectionNames.DataSourceInformation);
+            if (schema.Rows.Count > 0)
+            {
+                return schema.Rows[0].Field<string>("DataSourceProductName");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Could not get product name from schema metadata");
+        }
+
+        return null;
+    }
+
+    protected virtual string ExtractProductNameFromVersion(string versionString)
+    {
+        var lower = versionString?.ToLowerInvariant() ?? string.Empty;
+
+        if (lower.Contains("microsoft sql server"))
+        {
+            return "Microsoft SQL Server";
+        }
+
+        if (lower.Contains("mysql"))
+        {
+            return "MySQL";
+        }
+
+        if (lower.Contains("mariadb"))
+        {
+            return "MariaDB";
+        }
+
+        if (lower.Contains("postgresql"))
+        {
+            return "PostgreSQL";
+        }
+
+        if (lower.Contains("cockroach"))
+        {
+            return "CockroachDB";
+        }
+
+        if (lower.Contains("oracle"))
+        {
+            return "Oracle Database";
+        }
+
+        if (lower.Contains("sqlite"))
+        {
+            return "SQLite";
+        }
+
+        if (lower.Contains("firebird"))
+        {
+            return "Firebird";
+        }
+
+        return "Unknown Database";
+    }
+
+    protected virtual SupportedDatabase InferDatabaseTypeFromInfo(string productName, string versionString)
+    {
+        var combined = $"{productName} {versionString}".ToLowerInvariant();
+
+        if (combined.Contains("sql server"))
+        {
+            return SupportedDatabase.SqlServer;
+        }
+
+        if (combined.Contains("mariadb"))
+        {
+            return SupportedDatabase.MariaDb;
+        }
+
+        if (combined.Contains("mysql"))
+        {
+            return SupportedDatabase.MySql;
+        }
+
+        if (combined.Contains("cockroach"))
+        {
+            return SupportedDatabase.CockroachDb;
+        }
+
+        if (combined.Contains("npgsql") || combined.Contains("postgres"))
+        {
+            return SupportedDatabase.PostgreSql;
+        }
+
+        if (combined.Contains("oracle"))
+        {
+            return SupportedDatabase.Oracle;
+        }
+
+        if (combined.Contains("sqlite"))
+        {
+            return SupportedDatabase.Sqlite;
+        }
+
+        if (combined.Contains("firebird"))
+        {
+            return SupportedDatabase.Firebird;
+        }
+
+        return DatabaseType;
+    }
+
+    public virtual Version? ParseVersion(string versionString)
+    {
+        if (string.IsNullOrWhiteSpace(versionString))
+        {
+            return null;
+        }
+
+        var match = Regex.Match(versionString, @"(?<ver>\d+(?:\.\d+)*)");
+        if (match.Success && Version.TryParse(match.Groups["ver"].Value, out var version))
+        {
+            return version;
+        }
+
+        return null;
+    }
+
+    public virtual int? GetMajorVersion(string versionString)
+    {
+        return ParseVersion(versionString)?.Major;
+    }
+}

--- a/pengdows.crud/dialects/SqlDialectFactory.cs
+++ b/pengdows.crud/dialects/SqlDialectFactory.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Data.Common;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using pengdows.crud.enums;
+using pengdows.crud.wrappers;
+
+namespace pengdows.crud.dialects;
+
+/// <summary>
+/// Factory for creating dialect instances with automatic detection
+/// </summary>
+public static class SqlDialectFactory
+{
+    public static async Task<SqlDialect> CreateDialectAsync(
+        ITrackedConnection connection,
+        DbProviderFactory factory,
+        Func<int, int, string> nameGenerator,
+        ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger<SqlDialect>();
+
+        var inferredType = InferDatabaseTypeFromProvider(factory);
+        var dialect = CreateDialectForType(inferredType, factory, nameGenerator, logger);
+
+        try
+        {
+            var productInfo = await dialect.DetectDatabaseInfoAsync(connection);
+
+            if (productInfo.DatabaseType != inferredType && productInfo.DatabaseType != SupportedDatabase.Unknown)
+            {
+                logger.LogInformation(
+                    "Database type mismatch. Inferred: {Inferred}, Detected: {Detected}. Using detected type.",
+                    inferredType,
+                    productInfo.DatabaseType);
+
+                dialect = CreateDialectForType(productInfo.DatabaseType, factory, nameGenerator, logger);
+                await dialect.DetectDatabaseInfoAsync(connection);
+            }
+
+            return dialect;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to detect database type, falling back to inferred type: {Type}", inferredType);
+            return dialect;
+        }
+    }
+
+    public static SqlDialect CreateDialect(
+        ITrackedConnection connection,
+        DbProviderFactory factory,
+        Func<int, int, string> nameGenerator,
+        ILoggerFactory loggerFactory)
+    {
+        return CreateDialectAsync(connection, factory, nameGenerator, loggerFactory).GetAwaiter().GetResult();
+    }
+
+    public static SqlDialect CreateDialectForType(
+        SupportedDatabase databaseType,
+        DbProviderFactory factory,
+        Func<int, int, string> nameGenerator,
+        ILogger logger)
+    {
+        return databaseType switch
+        {
+            SupportedDatabase.SqlServer => new SqlServerDialect(factory, nameGenerator, logger),
+            SupportedDatabase.PostgreSql => new PostgreSqlDialect(factory, nameGenerator, logger),
+            SupportedDatabase.CockroachDb => new PostgreSqlDialect(factory, nameGenerator, logger),
+            SupportedDatabase.MySql => new MySqlDialect(factory, nameGenerator, logger),
+            SupportedDatabase.MariaDb => new MySqlDialect(factory, nameGenerator, logger),
+            SupportedDatabase.Sqlite => new SqliteDialect(factory, nameGenerator, logger),
+            SupportedDatabase.Oracle => new OracleDialect(factory, nameGenerator, logger),
+            SupportedDatabase.Firebird => throw new NotImplementedException("Firebird dialect not yet implemented"),
+            _ => throw new ArgumentException($"Unsupported database type: {databaseType}")
+        };
+    }
+
+    private static SupportedDatabase InferDatabaseTypeFromProvider(DbProviderFactory factory)
+    {
+        var typeName = factory.GetType().Name.ToLowerInvariant();
+
+        return typeName switch
+        {
+            var name when name.Contains("sqlserver") || name.Contains("system.data.sqlclient") => SupportedDatabase.SqlServer,
+            var name when name.Contains("npgsql") => SupportedDatabase.PostgreSql,
+            var name when name.Contains("mysql") => SupportedDatabase.MySql,
+            var name when name.Contains("sqlite") => SupportedDatabase.Sqlite,
+            var name when name.Contains("oracle") => SupportedDatabase.Oracle,
+            var name when name.Contains("firebird") => SupportedDatabase.Firebird,
+            _ => SupportedDatabase.Unknown
+        };
+    }
+}

--- a/pengdows.crud/dialects/SqlServerDialect.cs
+++ b/pengdows.crud/dialects/SqlServerDialect.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace pengdows.crud.dialects;
+
+/// <summary>
+/// SQL Server dialect with version-specific feature support
+/// </summary>
+public class SqlServerDialect : SqlDialect
+{
+    public SqlServerDialect(DbProviderFactory factory, Func<int, int, string> nameGenerator, ILogger logger)
+        : base(factory, nameGenerator, logger)
+    {
+    }
+
+    public override SupportedDatabase DatabaseType => SupportedDatabase.SqlServer;
+    public override string ParameterMarker => "@";
+    public override bool SupportsNamedParameters => true;
+    public override int MaxParameterLimit => 2100;
+    public override int ParameterNameMaxLength => 128;
+    public override ProcWrappingStyle ProcWrappingStyle => ProcWrappingStyle.Exec;
+
+    // SQL Server uses square brackets for quoting
+    public override string QuotePrefix => "[";
+    public override string QuoteSuffix => "]";
+
+    // SQL Server supports up to SQL:2016 features in recent versions
+    public override SqlStandardLevel MaxSupportedStandard => SqlStandardLevel.Sql2016;
+
+    // Version-specific overrides
+    public override bool SupportsMerge => true;
+    public override bool SupportsJsonTypes => IsInitialized && ProductInfo.ParsedVersion?.Major >= 13;
+
+    public override string GetVersionQuery() => "SELECT @@VERSION";
+
+    public override string GetConnectionSessionSettings()
+    {
+        return @"SET NOCOUNT ON;
+SET ANSI_NULLS ON;
+SET ANSI_PADDING ON;
+SET ANSI_WARNINGS ON;
+SET ARITHABORT ON;
+SET CONCAT_NULL_YIELDS_NULL ON;
+SET QUOTED_IDENTIFIER ON;
+SET NUMERIC_ROUNDABORT OFF;
+SET NOCOUNT OFF;";
+    }
+
+    public override void ApplyConnectionSettings(IDbConnection connection)
+    {
+        try
+        {
+            var settingsToApply = CheckSqlServerSettings(connection);
+
+            if (!string.IsNullOrEmpty(settingsToApply))
+            {
+                Logger.LogDebug("Applying SQL Server session settings: {Settings}", settingsToApply);
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = settingsToApply;
+                cmd.ExecuteNonQuery();
+            }
+            else
+            {
+                Logger.LogDebug("SQL Server session settings are already optimal, no changes needed");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to apply SQL Server connection settings");
+        }
+    }
+
+    private string CheckSqlServerSettings(IDbConnection connection)
+    {
+        try
+        {
+            var expectedSettings = new Dictionary<string, string>
+            {
+                { "ANSI_NULLS", "ON" },
+                { "ANSI_PADDING", "ON" },
+                { "ANSI_WARNINGS", "ON" },
+                { "ARITHABORT", "ON" },
+                { "CONCAT_NULL_YIELDS_NULL", "ON" },
+                { "QUOTED_IDENTIFIER", "ON" },
+                { "NUMERIC_ROUNDABORT", "OFF" }
+            };
+
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "DBCC USEROPTIONS;";
+
+            using var reader = cmd.ExecuteReader();
+            var currentSettings = expectedSettings.ToDictionary(kvp => kvp.Key, _ => "OFF");
+
+            while (reader.Read())
+            {
+                var settingName = reader.GetString(0).ToUpperInvariant();
+                var settingValue = reader.GetString(1);
+
+                if (expectedSettings.ContainsKey(settingName))
+                {
+                    currentSettings[settingName] = settingValue == "SET" ? "ON" : "OFF";
+                }
+            }
+
+            var sb = new StringBuilder();
+            foreach (var expectedSetting in expectedSettings)
+            {
+                var settingName = expectedSetting.Key;
+                var expectedValue = expectedSetting.Value;
+
+                currentSettings.TryGetValue(settingName, out var currentValue);
+
+                if (currentValue != expectedValue)
+                {
+                    if (sb.Length > 0)
+                    {
+                        sb.AppendLine();
+                    }
+
+                    sb.Append($"SET {settingName} {expectedValue}");
+                }
+            }
+
+            if (sb.Length > 0)
+            {
+                sb.Insert(0, "SET NOCOUNT ON;\n");
+                sb.AppendLine(";\nSET NOCOUNT OFF;");
+            }
+
+            return sb.ToString();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Failed to check SQL Server session settings, applying default settings");
+            return GetConnectionSessionSettings();
+        }
+    }
+
+    protected override SqlStandardLevel DetermineStandardCompliance(Version? version)
+    {
+        if (version == null)
+        {
+            return SqlStandardLevel.Sql2008;
+        }
+
+        return version.Major switch
+        {
+            >= 16 => SqlStandardLevel.Sql2016,
+            >= 15 => SqlStandardLevel.Sql2016,
+            >= 14 => SqlStandardLevel.Sql2016,
+            >= 13 => SqlStandardLevel.Sql2016,
+            >= 12 => SqlStandardLevel.Sql2011,
+            >= 11 => SqlStandardLevel.Sql2008,
+            >= 10 => SqlStandardLevel.Sql2008,
+            _ => SqlStandardLevel.Sql2003
+        };
+    }
+}

--- a/pengdows.crud/dialects/SqliteDialect.cs
+++ b/pengdows.crud/dialects/SqliteDialect.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace pengdows.crud.dialects;
+
+/// <summary>
+/// SQLite dialect with good standard compliance despite being embedded
+/// </summary>
+public class SqliteDialect : SqlDialect
+{
+    public SqliteDialect(DbProviderFactory factory, Func<int, int, string> nameGenerator, ILogger logger)
+        : base(factory, nameGenerator, logger)
+    {
+    }
+
+    public override SupportedDatabase DatabaseType => SupportedDatabase.Sqlite;
+    public override string ParameterMarker => "@";
+    public override bool SupportsNamedParameters => true;
+    public override int MaxParameterLimit => 999;
+    public override int ParameterNameMaxLength => 255;
+    public override ProcWrappingStyle ProcWrappingStyle => ProcWrappingStyle.None;
+
+    public override SqlStandardLevel MaxSupportedStandard => SqlStandardLevel.Sql2016;
+
+    public override bool SupportsInsertOnConflict => true;
+    public override bool SupportsMerge => false;
+    public override bool SupportsNamespaces => false;
+    public override bool SupportsJsonTypes => IsInitialized && ProductInfo.ParsedVersion >= new Version(3, 45);
+    public override bool SupportsWindowFunctions => IsInitialized && ProductInfo.ParsedVersion >= new Version(3, 25);
+    public override bool SupportsCommonTableExpressions => IsInitialized && ProductInfo.ParsedVersion >= new Version(3, 8, 3);
+
+    public override string GetVersionQuery() => "SELECT sqlite_version()";
+
+    public override string GetConnectionSessionSettings()
+    {
+        return "PRAGMA foreign_keys = ON;";
+    }
+
+    public override void ApplyConnectionSettings(IDbConnection connection)
+    {
+        try
+        {
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = GetConnectionSessionSettings();
+            cmd.ExecuteNonQuery();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to apply SQLite connection settings");
+        }
+    }
+
+    protected override async Task<string?> GetProductNameAsync(ITrackedConnection connection)
+    {
+        try
+        {
+            await using var cmd = (DbCommand)connection.CreateCommand();
+            cmd.CommandText = "SELECT sqlite_version()";
+            await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SingleRow);
+
+            if (await reader.ReadAsync())
+            {
+                return "SQLite";
+            }
+        }
+        catch
+        {
+        }
+
+        return null;
+    }
+
+    protected override string ExtractProductNameFromVersion(string versionString)
+    {
+        return "SQLite";
+    }
+
+    protected override SqlStandardLevel DetermineStandardCompliance(Version? version)
+    {
+        if (version == null)
+        {
+            return SqlStandardLevel.Sql92;
+        }
+
+        if (version.Major == 3)
+        {
+            return version.Minor switch
+            {
+                >= 45 => SqlStandardLevel.Sql2016,
+                >= 35 => SqlStandardLevel.Sql2011,
+                >= 25 => SqlStandardLevel.Sql2008,
+                >= 8 => SqlStandardLevel.Sql2003,
+                _ => SqlStandardLevel.Sql92
+            };
+        }
+
+        return SqlStandardLevel.Sql92;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce extensible SQL dialect hierarchy with automatic detection via a new `SqlDialectFactory`
- add dialect implementations with feature flags such as JSON support and session configuration
- add positive and negative tests for dialect feature detection and factory behavior

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a2529cf1a083258484928e135c7402