### PR TITLE
Improve session settings detection and parameter handling

### DIFF
--- a/pengdows.crud.Tests/MySqlSessionSettingsTests.cs
+++ b/pengdows.crud.Tests/MySqlSessionSettingsTests.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Data.Common;
+using pengdows.crud.configuration;
+using pengdows.crud.enums;
+using pengdows.crud.FakeDb;
+using Xunit;
+
+namespace pengdows.crud.Tests;
+
+public class MySqlSessionSettingsTests
+{
+    private sealed class RecordingConnection : FakeDbConnection
+    {
+        public List<string> ExecutedCommands { get; } = new();
+
+        protected override DbCommand CreateDbCommand()
+        {
+            return new RecordingCommand(this, ExecutedCommands);
+        }
+    }
+
+    private sealed class RecordingCommand : FakeDbCommand
+    {
+        private readonly List<string> _record;
+
+        public RecordingCommand(FakeDbConnection connection, List<string> record) : base(connection)
+        {
+            _record = record;
+        }
+
+        public override int ExecuteNonQuery()
+        {
+            _record.Add(CommandText);
+            return base.ExecuteNonQuery();
+        }
+    }
+
+    private sealed class RecordingFactory : DbProviderFactory
+    {
+        public RecordingConnection Connection { get; } = new();
+
+        public override DbConnection CreateConnection()
+        {
+            Connection.EmulatedProduct = SupportedDatabase.MySql;
+            return Connection;
+        }
+
+        public override DbCommand CreateCommand()
+        {
+            return new FakeDbCommand();
+        }
+
+        public override DbParameter CreateParameter()
+        {
+            return new FakeDbParameter();
+        }
+    }
+
+    [Fact]
+    public void SessionSettingsAppliedOnceInSingleConnectionMode()
+    {
+        var factory = new RecordingFactory();
+        var config = new DatabaseContextConfiguration
+        {
+            ConnectionString = $"Data Source=:memory:;EmulatedProduct={SupportedDatabase.MySql}",
+            ProviderName = SupportedDatabase.MySql.ToString(),
+            DbMode = DbMode.SingleConnection
+        };
+
+        using var ctx = new DatabaseContext(config, factory);
+        var count = factory.Connection.ExecutedCommands.Count(c => c.StartsWith("SET SESSION sql_mode"));
+        Assert.Equal(1, count);
+    }
+
+    [Fact]
+    public void SessionSettingsNotAppliedDuringConstructionInStandardMode()
+    {
+        var factory = new RecordingFactory();
+        var config = new DatabaseContextConfiguration
+        {
+            ConnectionString = $"Data Source=:memory:;EmulatedProduct={SupportedDatabase.MySql}",
+            ProviderName = SupportedDatabase.MySql.ToString(),
+            DbMode = DbMode.Standard
+        };
+
+        using var ctx = new DatabaseContext(config, factory);
+        var count = factory.Connection.ExecutedCommands.Count(c => c.StartsWith("SET SESSION sql_mode"));
+        Assert.Equal(0, count);
+    }
+}

--- a/pengdows.crud.Tests/ParameterCreationTests.cs
+++ b/pengdows.crud.Tests/ParameterCreationTests.cs
@@ -1,0 +1,35 @@
+using System.Data;
+using Microsoft.Extensions.Logging.Abstractions;
+using pengdows.crud.dialects;
+using pengdows.crud.enums;
+using pengdows.crud.FakeDb;
+using Xunit;
+
+namespace pengdows.crud.Tests;
+
+public class ParameterCreationTests
+{
+    private static SqlDialect CreateDialect()
+    {
+        var factory = new FakeDbFactory(SupportedDatabase.SqlServer);
+        return new SqlServerDialect(factory, NullLogger.Instance);
+    }
+
+    [Fact]
+    public void CreateDbParameter_WithDecimal_SetsPrecisionAndScale()
+    {
+        var dialect = CreateDialect();
+        var p = dialect.CreateDbParameter(null, DbType.Decimal, 123.45m);
+        Assert.Equal((byte)5, p.Precision);
+        Assert.Equal((byte)2, p.Scale);
+    }
+
+    [Fact]
+    public void CreateDbParameter_WithNullDecimal_DoesNotSetPrecision()
+    {
+        var dialect = CreateDialect();
+        var p = dialect.CreateDbParameter(null, DbType.Decimal, (decimal?)null);
+        Assert.Equal((byte)0, p.Precision);
+        Assert.Equal((byte)0, p.Scale);
+    }
+}

--- a/pengdows.crud.Tests/RcsidDetectionTests.cs
+++ b/pengdows.crud.Tests/RcsidDetectionTests.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Data.Common;
+using pengdows.crud.configuration;
+using pengdows.crud.enums;
+using pengdows.crud.FakeDb;
+using pengdows.crud.wrappers;
+using Xunit;
+
+namespace pengdows.crud.Tests;
+
+public class RcsidDetectionTests
+{
+    private static MethodInfo GetMethod()
+        => typeof(DatabaseContext).GetMethod("DetectRCSI", BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+    private static DatabaseContext CreateContext()
+    {
+        var config = new DatabaseContextConfiguration
+        {
+            ConnectionString = $"Data Source=:memory:;EmulatedProduct={SupportedDatabase.SqlServer}",
+            ProviderName = SupportedDatabase.SqlServer.ToString(),
+            DbMode = DbMode.SingleConnection
+        };
+        var factory = new FakeDbFactory(SupportedDatabase.SqlServer);
+        return new DatabaseContext(config, factory);
+    }
+
+    private static ITrackedConnection BuildConnection(int rcsiFlag)
+    {
+        var inner = new FakeDbConnection
+        {
+            ConnectionString = $"Data Source=:memory:;EmulatedProduct={SupportedDatabase.SqlServer}"
+        };
+        inner.EnqueueScalarResult(rcsiFlag);
+        inner.Open();
+        return new TrackedConnection(inner);
+    }
+
+    [Fact]
+    public void DetectRCSI_ReturnsTrueWhenEnabled()
+    {
+        using var ctx = CreateContext();
+        var method = GetMethod();
+        var conn = BuildConnection(1);
+        var result = (bool)method.Invoke(ctx, new object[] { conn });
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void DetectRCSI_ReturnsFalseWhenDisabled()
+    {
+        using var ctx = CreateContext();
+        var method = GetMethod();
+        var conn = BuildConnection(0);
+        var result = (bool)method.Invoke(ctx, new object[] { conn });
+        Assert.False(result);
+    }
+}

--- a/pengdows.crud.abstractions/configuration/IDatabaseContextConfiguration.cs
+++ b/pengdows.crud.abstractions/configuration/IDatabaseContextConfiguration.cs
@@ -30,5 +30,10 @@ public interface IDatabaseContextConfiguration
     /// Gets or sets whether the context is in read-only, write-only, or read-write mode.
     /// </summary>
     ReadWriteMode ReadWriteMode { get; set; }
+
+    /// <summary>
+    /// When true, applies a default search_path of 'public' for PostgreSQL connections.
+    /// </summary>
+    bool SetDefaultSearchPath { get; set; }
 }
 

--- a/pengdows.crud/DecimalHelpers.cs
+++ b/pengdows.crud/DecimalHelpers.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace pengdows.crud;
+
+public static class DecimalHelpers
+{
+    public static (int Precision, int Scale) Infer(decimal value)
+    {
+        var bits = decimal.GetBits(value);
+        var scale = (bits[3] >> 16) & 0x7F;
+        var abs = Math.Abs(value);
+        var precision = scale;
+        for (var temp = decimal.Truncate(abs); temp >= 1; temp /= 10)
+        {
+            precision++;
+        }
+        return (precision, scale);
+    }
+}

--- a/pengdows.crud/configuration/DatabaseContextConfiguration.cs
+++ b/pengdows.crud/configuration/DatabaseContextConfiguration.cs
@@ -12,4 +12,5 @@ public class DatabaseContextConfiguration : IDatabaseContextConfiguration
     public string ProviderName { get; set; }
     public DbMode DbMode { get; set; } = DbMode.Standard;
     public ReadWriteMode ReadWriteMode { get; set; } = ReadWriteMode.ReadWrite;
+    public bool SetDefaultSearchPath { get; set; }
 }


### PR DESCRIPTION
## Summary
- Detect SQL Server RCSI and initialize isolation resolver once
- Harden session settings for MySQL and PostgreSQL and improve SQL Server USEROPTIONS parsing
- Infer decimal precision/scale and string sizes for parameters and add related tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68a50cb46fc48325ba17b8815a4f0f66