### PR TITLE
Fix FakeDbParameter decimal precision tracking

### DIFF
--- a/pengdows.crud.Tests/fakeDb/FakeDbTests.cs
+++ b/pengdows.crud.Tests/fakeDb/FakeDbTests.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
 using pengdows.crud.FakeDb;
+using pengdows.crud.enums;
 using Xunit;
 
 namespace pengdows.crud.Tests.fakeDb;
@@ -26,6 +27,53 @@ public class FakeDbTests
         Assert.Null(param.SourceColumn);
         Assert.Null(param.Value);
         Assert.Equal(DbType.Object, param.DbType);
+    }
+
+    [Fact]
+    public void FakeDbParameter_DefaultPrecisionAndScale_AreZero()
+    {
+        var param = new FakeDbParameter();
+
+        Assert.Equal((byte)0, param.Precision);
+        Assert.Equal((byte)0, param.Scale);
+    }
+
+    [Fact]
+    public void FakeDbParameter_PrecisionAndScale_CanBeSet()
+    {
+        var param = new FakeDbParameter
+        {
+            Precision = 5,
+            Scale = 2
+        };
+
+        Assert.Equal((byte)5, param.Precision);
+        Assert.Equal((byte)2, param.Scale);
+    }
+
+    [Fact]
+    public void FakeDbFactory_CreateParameter_ReturnsFakeDbParameter()
+    {
+        var factory = new FakeDbFactory(SupportedDatabase.SqlServer);
+        var param = factory.CreateParameter();
+
+        Assert.IsType<FakeDbParameter>(param);
+    }
+
+    [Fact]
+    public void FakeDbFactory_CreateParameter_PrecisionAndScale_CanBeSet()
+    {
+        var factory = new FakeDbFactory(SupportedDatabase.SqlServer);
+        var param = (FakeDbParameter)factory.CreateParameter();
+
+        Assert.Equal((byte)0, param.Precision);
+        Assert.Equal((byte)0, param.Scale);
+
+        param.Precision = 3;
+        param.Scale = 1;
+
+        Assert.Equal((byte)3, param.Precision);
+        Assert.Equal((byte)1, param.Scale);
     }
 
     [Fact]

--- a/pengdows.crud.fakeDb/FakeDbParameter.cs
+++ b/pengdows.crud.fakeDb/FakeDbParameter.cs
@@ -21,6 +21,8 @@ public class FakeDbParameter : DbParameter, IDbDataParameter
     [AllowNull]
     public override object Value { get; set; }
     public override int Size { get; set; }
+    public override byte Precision { get; set; }
+    public override byte Scale { get; set; }
 
     public override void ResetDbType()
     {


### PR DESCRIPTION
## Summary
- ensure `FakeDbParameter` preserves `Precision` and `Scale`
- add tests for default and custom precision/scale values
- verify `FakeDbFactory` produces precision-aware parameters

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68aa4dc608808325ac8fb501429f6ffa