### PR TITLE
Add coverage for DataSourceInformation and transaction behaviors

### DIFF
--- a/pengdows.crud.Tests/EntityHelperInvalidValueExceptionTests.cs
+++ b/pengdows.crud.Tests/EntityHelperInvalidValueExceptionTests.cs
@@ -1,0 +1,113 @@
+#region
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+using pengdows.crud.attributes;
+using pengdows.crud.exceptions;
+using pengdows.crud.FakeDb;
+using pengdows.crud.wrappers;
+using Xunit;
+
+#endregion
+
+namespace pengdows.crud.Tests;
+
+public class EntityHelperInvalidValueExceptionTests : SqlLiteContextTestBase
+{
+    private readonly EntityHelper<SetterThrowsEntity, int> _helper;
+
+    public EntityHelperInvalidValueExceptionTests()
+    {
+        TypeMap.Register<SetterThrowsEntity>();
+        _helper = new EntityHelper<SetterThrowsEntity, int>(Context);
+    }
+
+    [Fact]
+    public void MapReaderToObject_PropertySetterThrows_ThrowsInvalidValueException()
+    {
+        var rows = new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["Id"] = 1,
+                ["Name"] = "bad"
+            }
+        };
+
+        using var reader = new FakeTrackedReader(rows);
+        reader.Read();
+
+        Assert.Throws<InvalidValueException>(() => _helper.MapReaderToObject(reader));
+    }
+
+    [Fact]
+    public void MapReaderToObject_ValidValue_ReturnsEntity()
+    {
+        var rows = new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["Id"] = 1,
+                ["Name"] = "good"
+            }
+        };
+
+        using var reader = new FakeTrackedReader(rows);
+        reader.Read();
+
+        var entity = _helper.MapReaderToObject(reader);
+        Assert.Equal("good", entity.Name);
+    }
+
+    [Table("SetterThrows")]
+    private sealed class SetterThrowsEntity
+    {
+        [Id(false)]
+        [Column("Id", DbType.Int32)]
+        public int Id { get; set; }
+
+        private string _name = string.Empty;
+
+        [Column("Name", DbType.String)]
+        public string Name
+        {
+            get => _name;
+            set
+            {
+                if (value == "bad")
+                {
+                    throw new Exception("bad value");
+                }
+
+                _name = value;
+            }
+        }
+    }
+
+    private sealed class FakeTrackedReader : FakeDbDataReader, ITrackedReader
+    {
+        public FakeTrackedReader(IEnumerable<Dictionary<string, object>> rows) : base(rows)
+        {
+        }
+
+        public new Task<bool> ReadAsync()
+        {
+            return base.ReadAsync(CancellationToken.None);
+        }
+
+        public override ValueTask DisposeAsync()
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        public override Type GetFieldType(int ordinal)
+        {
+            var value = GetValue(ordinal);
+            return value?.GetType() ?? typeof(object);
+        }
+    }
+}
+

--- a/pengdows.crud.Tests/ExceptionTests.cs
+++ b/pengdows.crud.Tests/ExceptionTests.cs
@@ -16,4 +16,11 @@ public class ExceptionTests
         Assert.Equal("Exceeded", ex.Message);
         Assert.Equal(2000, ex.MaxAllowed);
     }
+
+    [Fact]
+    public void InvalidValueException_CarriesMessage()
+    {
+        var ex = new InvalidValueException("bad value");
+        Assert.Equal("bad value", ex.Message);
+    }
 }

--- a/pengdows.crud.Tests/Uuid7OptimizedTests.cs
+++ b/pengdows.crud.Tests/Uuid7OptimizedTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace pengdows.crud.Tests;
+
+public class Uuid7OptimizedTests
+{
+    [Fact]
+    public void NewUuid7_GeneratesVersion7AndRfcVariant()
+    {
+        var guid = Uuid7Optimized.NewUuid7();
+        var bytes = guid.ToByteArray();
+
+        var version = (bytes[7] >> 4) & 0x0F;
+        var variant = (bytes[8] >> 6) & 0x03;
+
+        Assert.Equal(0x7, version);
+        Assert.Equal(0x2, variant);
+    }
+
+    [Fact]
+    public void NewUuid7Bytes_WritesBytes_WithVersionAndVariant()
+    {
+        Span<byte> dest = stackalloc byte[16];
+        Uuid7Optimized.NewUuid7Bytes(dest);
+
+        var version = (dest[7] >> 4) & 0x0F;
+        var variant = (dest[8] >> 6) & 0x03;
+
+        Assert.Equal(0x7, version);
+        Assert.Equal(0x2, variant);
+    }
+
+    [Fact]
+    public void NewUuid7Bytes_ThrowsWhenSpanTooSmall()
+    {
+        byte[] dest = new byte[15];
+        Assert.Throws<ArgumentException>(() => Uuid7Optimized.NewUuid7Bytes(dest));
+    }
+
+    [Fact]
+    public void NewUuid7RfcBytes_WritesRfcOrder_WithVersionAndVariant()
+    {
+        Span<byte> dest = stackalloc byte[16];
+        Uuid7Optimized.NewUuid7RfcBytes(dest);
+
+        var version = (dest[6] >> 4) & 0x0F;
+        var variant = (dest[8] >> 6) & 0x03;
+
+        Assert.Equal(0x7, version);
+        Assert.Equal(0x2, variant);
+    }
+
+    [Fact]
+    public void NewUuid7RfcBytes_ThrowsWhenSpanTooSmall()
+    {
+        byte[] dest = new byte[15];
+        Assert.Throws<ArgumentException>(() => Uuid7Optimized.NewUuid7RfcBytes(dest));
+    }
+
+    [Fact]
+    public void TryNewUuid7_ReturnsTrueAndGuid()
+    {
+        var success = Uuid7Optimized.TryNewUuid7(out var guid);
+        Assert.True(success);
+        Assert.NotEqual(Guid.Empty, guid);
+    }
+
+    [Fact]
+    public void TryNewUuid7_ReturnsFalseWhenCounterExhausted()
+    {
+        Uuid7Optimized.NewUuid7();
+        var field = typeof(Uuid7Optimized).GetField("_threadState", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var threadLocal = field.GetValue(null)!;
+        var valueProp = threadLocal.GetType().GetProperty("Value")!;
+        var state = valueProp.GetValue(threadLocal)!;
+        var counterField = state.GetType().GetField("Counter")!;
+        var lastMsField = state.GetType().GetField("LastMs")!;
+
+        var originalCounter = (int)counterField.GetValue(state)!;
+        var originalLastMs = (long)lastMsField.GetValue(state)!;
+
+        try
+        {
+            lastMsField.SetValue(state, long.MaxValue);
+            counterField.SetValue(state, 4096);
+
+            var result = Uuid7Optimized.TryNewUuid7(out var guid);
+            Assert.False(result);
+            Assert.Equal(Guid.Empty, guid);
+        }
+        finally
+        {
+            counterField.SetValue(state, originalCounter);
+            lastMsField.SetValue(state, originalLastMs);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- test DataSourceInformation exposes parameter marker and name rules
- verify DataSourceInformation.Create throws for null connection or factory
- add tests validating Uuid7Optimized version, variant, span bounds, and counter overflow handling
- exercise InvalidValueException by mapping a bad value and confirming its message
- check TransactionContext rollback logic and property passthroughs

## Testing
- `dotnet test pengdows.crud.Tests/pengdows.crud.Tests.csproj --collect:"XPlat Code Coverage" -v minimal -p:WarningLevel=0`


------
https://chatgpt.com/codex/tasks/task_e_68aa5107a17c8325af2a97ba8e1cd122