### PR TITLE
feat: add duckdb test container

### DIFF
--- a/pengdows.crud.Tests/DatabaseContextTests.cs
+++ b/pengdows.crud.Tests/DatabaseContextTests.cs
@@ -242,6 +242,22 @@ public class DatabaseContextTests
     }
 
     [Fact]
+    public void DuckDbInMemory_SetsSingleConnectionMode()
+    {
+        var factory = new FakeDbFactory(SupportedDatabase.DuckDb);
+        using var context = new DatabaseContext("Data Source=:memory:;EmulatedProduct=DuckDb", factory);
+        Assert.Equal(DbMode.SingleConnection, context.ConnectionMode);
+    }
+
+    [Fact]
+    public void DuckDbFile_SetsSingleWriterMode()
+    {
+        var factory = new FakeDbFactory(SupportedDatabase.DuckDb);
+        using var context = new DatabaseContext("Data Source=test;EmulatedProduct=DuckDb", factory);
+        Assert.Equal(DbMode.SingleWriter, context.ConnectionMode);
+    }
+
+    [Fact]
     public void BeginTransaction_ReadOnly_InvalidIsolation_Throws()
     {
         var product = SupportedDatabase.Sqlite;

--- a/pengdows.crud.Tests/DuckDbTestContainerTests.cs
+++ b/pengdows.crud.Tests/DuckDbTestContainerTests.cs
@@ -1,0 +1,41 @@
+#region
+
+using Microsoft.Extensions.DependencyInjection;
+using pengdows.crud;
+using testbed;
+using Xunit;
+using System.Threading.Tasks;
+using System;
+using pengdows.crud.enums;
+
+#endregion
+
+namespace pengdows.crud.Tests;
+
+public class DuckDbTestContainerTests
+{
+    [Fact]
+    public async Task GetDatabaseContextAsync_ReturnsContext_WhenStarted()
+    {
+        await using var container = new DuckDbTestContainer();
+        await container.StartAsync();
+        var services = new ServiceCollection()
+            .AddSingleton<ITypeMapRegistry, TypeMapRegistry>()
+            .BuildServiceProvider();
+
+        await using var ctx = await container.GetDatabaseContextAsync(services);
+        Assert.Equal(SupportedDatabase.DuckDb, ctx.Product);
+    }
+
+    [Fact]
+    public async Task GetDatabaseContextAsync_WithoutStart_Throws()
+    {
+        await using var container = new DuckDbTestContainer();
+        var services = new ServiceCollection()
+            .AddSingleton<ITypeMapRegistry, TypeMapRegistry>()
+            .BuildServiceProvider();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await container.GetDatabaseContextAsync(services));
+    }
+}

--- a/pengdows.crud/DatabaseContext.cs
+++ b/pengdows.crud/DatabaseContext.cs
@@ -110,13 +110,22 @@ public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext, IConte
                 _dialect.ApplyConnectionSettings(initialConnection);
             }
 
-            if (_dataSourceInfo.Product == SupportedDatabase.Sqlite)
+            switch (_dataSourceInfo.Product)
             {
-                var csb = GetFactoryConnectionStringBuilder(string.Empty);
-                var ds = csb["Data Source"] as string;
-                ConnectionMode = ":memory:" == ds
-                    ? DbMode.SingleConnection
-                    : DbMode.SingleWriter;
+                case SupportedDatabase.Sqlite:
+                case SupportedDatabase.DuckDb:
+                {
+                    var csb = GetFactoryConnectionStringBuilder(string.Empty);
+                    var ds = csb["Data Source"] as string;
+                    ConnectionMode = ":memory:" == ds
+                        ? DbMode.SingleConnection
+                        : DbMode.SingleWriter;
+                    break;
+                }
+                default:
+                {
+                    break;
+                }
             }
 
             _isolationResolver = new IsolationResolver(Product, RCSIEnabled);

--- a/pengdows.crud/connection/KeepAliveConnectionStrategy.cs
+++ b/pengdows.crud/connection/KeepAliveConnectionStrategy.cs
@@ -1,12 +1,56 @@
+using pengdows.crud.enums;
 using pengdows.crud.wrappers;
+using pengdows.crud.infrastructure;
 
 namespace pengdows.crud.connection;
 
-internal sealed class KeepAliveConnectionStrategy : StandardConnectionStrategy
+internal sealed class KeepAliveConnectionStrategy : SafeAsyncDisposableBase, IConnectionStrategy
 {
+    private readonly Func<ITrackedConnection> _factory;
+    private readonly ITrackedConnection _sentinelConnection;
+
     public KeepAliveConnectionStrategy(Func<ITrackedConnection> factory)
-        : base(factory)
     {
+        _factory = factory ?? throw new ArgumentNullException(nameof(factory));
+        _sentinelConnection = factory();
+        _sentinelConnection.Open();
+    }
+
+    public ITrackedConnection GetConnection(ExecutionType executionType, bool isShared = false)
+    {
+        return _factory();
+    }
+
+    public void ReleaseConnection(ITrackedConnection? connection)
+    {
+        if (connection != null && !ReferenceEquals(connection, _sentinelConnection))
+        {
+            connection.Dispose();
+        }
+    }
+
+    public async ValueTask ReleaseConnectionAsync(ITrackedConnection? connection)
+    {
+        if (connection != null && !ReferenceEquals(connection, _sentinelConnection))
+        {
+            if (connection is IAsyncDisposable asyncDisposable)
+            {
+                await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+            }
+            else
+            {
+                connection.Dispose();
+            }
+        }
+    }
+
+    protected override void DisposeManaged()
+    {
+        _sentinelConnection.Dispose();
+    }
+
+    protected override async ValueTask DisposeManagedAsync()
+    {
+        await _sentinelConnection.DisposeAsync().ConfigureAwait(false);
     }
 }
-

--- a/testbed/DuckDb/DuckDbTestContainer.cs
+++ b/testbed/DuckDb/DuckDbTestContainer.cs
@@ -1,0 +1,34 @@
+#region
+
+using DuckDB.NET.Data;
+using Microsoft.Extensions.DependencyInjection;
+using pengdows.crud;
+
+#endregion
+
+namespace testbed;
+
+public class DuckDbTestContainer : TestContainer
+{
+    private string? _connectionString;
+
+    public override Task StartAsync()
+    {
+        _connectionString = "Data Source=:memory:";
+        return Task.CompletedTask;
+    }
+
+    public override Task<IDatabaseContext> GetDatabaseContextAsync(IServiceProvider services)
+    {
+        if (_connectionString == null)
+        {
+            throw new InvalidOperationException("Container not started yet.");
+        }
+
+        var context = new DatabaseContext(
+            _connectionString,
+            DuckDBClientFactory.Instance,
+            services.GetRequiredService<ITypeMapRegistry>());
+        return Task.FromResult<IDatabaseContext>(context);
+    }
+}

--- a/testbed/Program.cs
+++ b/testbed/Program.cs
@@ -34,14 +34,8 @@ await using (var liteDb = new DatabaseContext("Data Source=mydb.sqlite", SqliteF
     await lite.RunTest();
     liteDb.Dispose();
 }
-
-// await using (var duck = new DatabaseContext("Server=localhost;Port=54321;Database=duckdb;Pooling=true;",))
-//                DbProviderFactoryFinder.GetFactory("DuckDB.Data.DuckDBClient.DuckDBProviderFactory")!,
-//                host.Services.GetRequiredService<ITypeMapRegistry>()))
-// {
-//     var d = new TestProvider(duck, host.Services);
-//     await d.RunTest();
-// }
+await using var duck = new DuckDbTestContainer();
+await duck.RunTestWithContainerAsync<TestProvider>(host.Services, (db, sp) => new TestProvider(db, sp));
 // var cs = $"DataSource=localhost;Port=5000;Database={0};Uid=sa;Pwd=MyStr0ngP@ssw0rd;";
 //
 // // wait for ASE to be ready

--- a/testbed/testbed.csproj
+++ b/testbed/testbed.csproj
@@ -17,7 +17,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="DuckDB.NET.Data" Version="1.3.2" />
+        <PackageReference Include="DuckDB.NET.Data.Full" Version="1.3.2" />
         <PackageReference Include="FirebirdSql.Data.FirebirdClient" Version="10.3.3"/>
         <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.2"/>
         <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.5"/>


### PR DESCRIPTION
## Summary
- add DuckDB test container using in-memory database
- run DuckDB container in testbed program
- verify DuckDB container behavior with positive and negative tests
- implement keep-alive connection strategy ensuring sentinel connection remains open
- set DuckDB connection mode based on data source and cover with tests

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68aa73831e24832585601385cf0552e1