### PR TITLE
Add async disposal tests and expand SQL dialect coverage

### DIFF
--- a/pengdows.crud.Tests/DialectCoverageTests.cs
+++ b/pengdows.crud.Tests/DialectCoverageTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Microsoft.Extensions.Logging.Abstractions;
 using pengdows.crud.dialects;
 using pengdows.crud.enums;
@@ -8,43 +9,112 @@ namespace pengdows.crud.Tests;
 
 public class DialectCoverageTests
 {
-    [Fact]
-    public void MySqlDialect_WrapObjectName_WrapsWithBackticks()
+    public static IEnumerable<object[]> DialectData()
     {
-        var dialect = new MySqlDialect(
-            new FakeDbFactory(SupportedDatabase.MySql),
-            NullLogger<MySqlDialect>.Instance);
+        yield return new object[]
+        {
+            new MySqlDialect(new FakeDbFactory(SupportedDatabase.MySql), NullLogger<MySqlDialect>.Instance),
+            "`",
+            true,
+            "@"
+        };
+
+        yield return new object[]
+        {
+            new OracleDialect(new FakeDbFactory(SupportedDatabase.Oracle), NullLogger<OracleDialect>.Instance),
+            "\"",
+            true,
+            ":"
+        };
+
+        yield return new object[]
+        {
+            new DuckDbDialect(new FakeDbFactory(SupportedDatabase.DuckDb), NullLogger<DuckDbDialect>.Instance),
+            "\"",
+            true,
+            "$"
+        };
+
+        yield return new object[]
+        {
+            new Sql92Dialect(new FakeDbFactory(SupportedDatabase.Unknown), NullLogger<Sql92Dialect>.Instance),
+            "\"",
+            false,
+            "?"
+        };
+
+        yield return new object[]
+        {
+            new PostgreSqlDialect(new FakeDbFactory(SupportedDatabase.PostgreSql), NullLogger<PostgreSqlDialect>.Instance),
+            "\"",
+            true,
+            ":"
+        };
+
+        yield return new object[]
+        {
+            new SqlServerDialect(new FakeDbFactory(SupportedDatabase.SqlServer), NullLogger<SqlServerDialect>.Instance),
+            "\"",
+            true,
+            "@"
+        };
+
+        yield return new object[]
+        {
+            new SqliteDialect(new FakeDbFactory(SupportedDatabase.Sqlite), NullLogger<SqliteDialect>.Instance),
+            "\"",
+            true,
+            "@"
+        };
+
+        yield return new object[]
+        {
+            new FirebirdDialect(new FakeDbFactory(SupportedDatabase.Firebird), NullLogger<FirebirdDialect>.Instance),
+            "\"",
+            true,
+            "@"
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(DialectData))]
+    public void WrapObjectName_WrapsIdentifier(SqlDialect dialect, string quote, bool supportsNamed, string marker)
+    {
         var wrapped = dialect.WrapObjectName("schema.table");
-        Assert.Equal("`schema`.`table`", wrapped);
+        Assert.Equal($"{quote}schema{quote}.{quote}table{quote}", wrapped);
+        Assert.NotEqual("schema.table", wrapped);
     }
 
-    [Fact]
-    public void MySqlDialect_WrapObjectName_Null_ReturnsEmpty()
+    [Theory]
+    [MemberData(nameof(DialectData))]
+    public void WrapObjectName_Null_ReturnsEmpty(SqlDialect dialect, string quote, bool supportsNamed, string marker)
     {
-        var dialect = new MySqlDialect(
-            new FakeDbFactory(SupportedDatabase.MySql),
-            NullLogger<MySqlDialect>.Instance);
         var wrapped = dialect.WrapObjectName(null);
         Assert.Equal(string.Empty, wrapped);
+        Assert.NotNull(wrapped);
     }
 
-    [Fact]
-    public void OracleDialect_MakeParameterName_PrefixesWithColon()
+    [Theory]
+    [MemberData(nameof(DialectData))]
+    public void MakeParameterName_UsesMarker(SqlDialect dialect, string quote, bool supportsNamed, string marker)
     {
-        var dialect = new OracleDialect(
-            new FakeDbFactory(SupportedDatabase.Oracle),
-            NullLogger<OracleDialect>.Instance);
-        var name = dialect.MakeParameterName("p1");
-        Assert.Equal(":p1", name);
-    }
-
-    [Fact]
-    public void OracleDialect_WrapObjectName_Null_ReturnsEmpty()
-    {
-        var dialect = new OracleDialect(
-            new FakeDbFactory(SupportedDatabase.Oracle),
-            NullLogger<OracleDialect>.Instance);
-        var wrapped = dialect.WrapObjectName(null);
-        Assert.Equal(string.Empty, wrapped);
+        var name = dialect.MakeParameterName("p");
+        if (supportsNamed)
+        {
+            Assert.Equal($"{marker}p", name);
+            var unexpectedMarker = marker switch
+            {
+                "@" => ":",
+                ":" => "@",
+                "$" => "@",
+                _ => "$"
+            };
+            Assert.NotEqual($"{unexpectedMarker}p", name);
+        }
+        else
+        {
+            Assert.Equal("?", name);
+            Assert.NotEqual("?p", name);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add coverage for KeepAliveConnectionStrategy.DisposeAsync
- add sync fallback test for KeepAliveConnectionStrategy.ReleaseConnectionAsync
- exercise all SQL dialects for identifier wrapping and parameter marker handling

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ab4af06ab88325931ba2ebc4e937a2