### PR TITLE
docs: add XML documentation to interfaces

### DIFF
--- a/pengdows.crud.Tests/ContextIdentityTests.cs
+++ b/pengdows.crud.Tests/ContextIdentityTests.cs
@@ -16,6 +16,13 @@ public class ContextIdentityTests : SqlLiteContextTestBase
     }
 
     [Fact]
+    public void ContextIdentity_Interface_IsInternal()
+    {
+        Assert.False(typeof(IContextIdentity).IsPublic);
+        Assert.True(typeof(IContextIdentity).IsNotPublic);
+    }
+
+    [Fact]
     public void BuildBaseRetrieve_WithTransactionFromSameRoot_Succeeds()
     {
         using var tx = Context.BeginTransaction();

--- a/pengdows.crud.abstractions/IAuditValueResolver.cs
+++ b/pengdows.crud.abstractions/IAuditValueResolver.cs
@@ -1,6 +1,13 @@
 namespace pengdows.crud;
 
+/// <summary>
+/// Resolves <see cref="IAuditValues"/> for the current execution context.
+/// </summary>
 public interface IAuditValueResolver
 {
+    /// <summary>
+    /// Generates audit values describing the current user and time.
+    /// </summary>
+    /// <returns>Resolved audit metadata.</returns>
     IAuditValues Resolve();
 }

--- a/pengdows.crud.abstractions/IAuditValues.cs
+++ b/pengdows.crud.abstractions/IAuditValues.cs
@@ -1,10 +1,31 @@
+#region
+
+using System;
+
+#endregion
+
 namespace pengdows.crud;
 
+/// <summary>
+/// Represents immutable audit metadata for database operations.
+/// </summary>
 public interface IAuditValues
 {
+    /// <summary>
+    /// Identifier of the current user associated with the audit entry.
+    /// </summary>
     object UserId { get; init; }
+
+    /// <summary>
+    /// Timestamp, in UTC, when the audit entry was generated.
+    /// </summary>
     DateTime UtcNow { get; }
 
+    /// <summary>
+    /// Returns the <see cref="UserId"/> cast to the specified type.
+    /// </summary>
+    /// <typeparam name="T">Type to cast the identifier to.</typeparam>
+    /// <returns>The user identifier as the requested type.</returns>
     T As<T>()
     {
         return (T)UserId;

--- a/pengdows.crud.abstractions/IColumnInfo.cs
+++ b/pengdows.crud.abstractions/IColumnInfo.cs
@@ -8,26 +8,112 @@ using System.Text.Json;
 
 namespace pengdows.crud;
 
+/// <summary>
+/// Describes metadata and behavior for a table column.
+/// </summary>
 public interface IColumnInfo
 {
+    /// <summary>
+    /// Column name as declared in the database.
+    /// </summary>
     string Name { get; init; }
+
+    /// <summary>
+    /// Property associated with this column.
+    /// </summary>
     PropertyInfo PropertyInfo { get; init; }
+
+    /// <summary>
+    /// Indicates whether this column represents the row identifier (pseudo key)
+    /// rather than a business-defined primary key.
+    /// </summary>
     bool IsId { get; init; }
+
+    /// <summary>
+    /// Database type for the column.
+    /// </summary>
     DbType DbType { get; set; }
+
+    /// <summary>
+    /// True when the column should not be updated.
+    /// </summary>
     bool IsNonUpdateable { get; set; }
+
+    /// <summary>
+    /// True when the column should not be inserted.
+    /// </summary>
     bool IsNonInsertable { get; set; }
+
+    /// <summary>
+    /// Indicates whether the column maps to an enum.
+    /// </summary>
     bool IsEnum { get; set; }
+
+    /// <summary>
+    /// Enum type used when <see cref="IsEnum"/> is true.
+    /// </summary>
     Type? EnumType { get; set; }
+
+    /// <summary>
+    /// True when the column stores JSON data.
+    /// </summary>
     bool IsJsonType { get; set; }
+
+    /// <summary>
+    /// Options used for JSON serialization.
+    /// </summary>
     JsonSerializerOptions JsonSerializerOptions { get; set; }
+
+    /// <summary>
+    /// Indicates whether the identifier column is writable.
+    /// </summary>
     bool IsIdIsWritable { get; set; }
+
+    /// <summary>
+    /// True when the column participates in the primary key.
+    /// </summary>
     bool IsPrimaryKey { get; set; }
+
+    /// <summary>
+    /// Order of the column within a composite primary key.
+    /// </summary>
     int PkOrder { get; set; }
+
+    /// <summary>
+    /// Indicates whether the column stores optimistic concurrency tokens.
+    /// </summary>
     bool IsVersion { get; set; }
+
+    /// <summary>
+    /// True when the column captures the creator identifier.
+    /// </summary>
     bool IsCreatedBy { get; set; }
+
+    /// <summary>
+    /// True when the column captures the creation timestamp.
+    /// </summary>
     bool IsCreatedOn { get; set; }
+
+    /// <summary>
+    /// True when the column captures the last updater identifier.
+    /// </summary>
     bool IsLastUpdatedBy { get; set; }
+
+    /// <summary>
+    /// True when the column captures the last update timestamp.
+    /// </summary>
     bool IsLastUpdatedOn { get; set; }
+
+    /// <summary>
+    /// Ordinal position of the column within the table.
+    /// </summary>
     int Ordinal { get; set; }
+
+    /// <summary>
+    /// Creates a parameter value from the entity field for use in commands.
+    /// </summary>
+    /// <typeparam name="T">Entity type.</typeparam>
+    /// <param name="objectToCreate">Entity instance.</param>
+    /// <returns>The value to use for a parameter.</returns>
     object? MakeParameterValueFromField<T>(T objectToCreate);
 }

--- a/pengdows.crud.abstractions/IEntityHelper.cs
+++ b/pengdows.crud.abstractions/IEntityHelper.cs
@@ -42,7 +42,7 @@ public interface IEntityHelper<TEntity, TRowID> where TEntity : class, new()
     ISqlContainer BuildBaseRetrieve(string alias, IDatabaseContext? context = null);
 
     /// <summary>
-    /// Builds a SQL SELECT for a list of row IDs.
+    /// Builds a SQL SELECT for a list of row IDs (pseudo keys).
     /// </summary>
     ISqlContainer BuildRetrieve(IReadOnlyCollection<TRowID>? listOfIds, string alias,
         IDatabaseContext? context = null);
@@ -54,7 +54,7 @@ public interface IEntityHelper<TEntity, TRowID> where TEntity : class, new()
         IDatabaseContext? context = null);
 
     /// <summary>
-    /// Overload for retrieving by ID without alias.
+    /// Overload for retrieving by row IDs (pseudo keys) without alias.
     /// </summary>
     ISqlContainer BuildRetrieve(IReadOnlyCollection<TRowID>? listOfIds, IDatabaseContext? context = null);
 
@@ -74,22 +74,22 @@ public interface IEntityHelper<TEntity, TRowID> where TEntity : class, new()
     Task<ISqlContainer> BuildUpdateAsync(TEntity objectToUpdate, bool loadOriginal, IDatabaseContext? context = null);
 
     /// <summary>
-    /// Builds a DELETE by primary key.
+    /// Builds a DELETE by row identifier (pseudo key).
     /// </summary>
     ISqlContainer BuildDelete(TRowID id, IDatabaseContext? context = null);
 
     /// <summary>
-    /// Executes a DELETE for the given primary key and returns the number of affected rows.
+    /// Executes a DELETE for the given row identifier (pseudo key) and returns the number of affected rows.
     /// </summary>
     Task<int> DeleteAsync(TRowID id, IDatabaseContext? context = null);
 
     /// <summary>
-    /// Loads all entities matching the provided IDs.
+    /// Loads all entities matching the provided row IDs (pseudo keys).
     /// </summary>
     Task<List<TEntity>> RetrieveAsync(IEnumerable<TRowID> ids, IDatabaseContext? context = null);
 
     /// <summary>
-    /// Executes a DELETE for all provided IDs and returns the number of affected rows.
+    /// Executes a DELETE for all provided row IDs (pseudo keys) and returns the number of affected rows.
     /// </summary>
     Task<int> DeleteAsync(IEnumerable<TRowID> ids, IDatabaseContext? context = null);
 

--- a/pengdows.crud.abstractions/IEphemeralSecureString.cs
+++ b/pengdows.crud.abstractions/IEphemeralSecureString.cs
@@ -1,7 +1,25 @@
+#region
+
+using System;
+
+#endregion
+
 namespace pengdows.crud;
 
+/// <summary>
+/// Provides access to a secure string that is revealed only for the duration of an operation.
+/// </summary>
 public interface IEphemeralSecureString : IDisposable
 {
+    /// <summary>
+    /// Reveals the protected string value.
+    /// </summary>
+    /// <returns>The underlying plain string.</returns>
     string Reveal();
+
+    /// <summary>
+    /// Executes an action with the revealed string and then re-secures it.
+    /// </summary>
+    /// <param name="use">Action to perform using the plain string.</param>
     void WithRevealed(Action<string> use);
 }

--- a/pengdows.crud.abstractions/ITableInfo.cs
+++ b/pengdows.crud.abstractions/ITableInfo.cs
@@ -1,15 +1,61 @@
+#region
+
+using System.Collections.Generic;
+
+#endregion
+
 namespace pengdows.crud;
 
+/// <summary>
+/// Describes table-level metadata and associated column mappings.
+/// </summary>
 public interface ITableInfo
 {
+    /// <summary>
+    /// Schema that owns the table.
+    /// </summary>
     string Schema { get; set; }
+
+    /// <summary>
+    /// Name of the table.
+    /// </summary>
     string Name { get; set; }
+
+    /// <summary>
+    /// Collection of columns keyed by property name.
+    /// </summary>
     Dictionary<string, IColumnInfo> Columns { get; }
+
+    /// <summary>
+    /// Column representing the pseudo key used to uniquely identify a row.
+    /// This <c>Id</c> differs from any business-defined <see cref="IColumnInfo.IsPrimaryKey"/>
+    /// columns and should not be mistaken for the primary key.
+    /// </summary>
     IColumnInfo Id { get; set; }
+
+    /// <summary>
+    /// Column used for optimistic concurrency checks.
+    /// </summary>
     IColumnInfo Version { get; set; }
+
+    /// <summary>
+    /// Column capturing the last updater identifier.
+    /// </summary>
     IColumnInfo LastUpdatedBy { get; set; }
+
+    /// <summary>
+    /// Column capturing the last update timestamp.
+    /// </summary>
     IColumnInfo LastUpdatedOn { get; set; }
+
+    /// <summary>
+    /// Column capturing the creation timestamp.
+    /// </summary>
     IColumnInfo CreatedOn { get; set; }
+
+    /// <summary>
+    /// Column capturing the creator identifier.
+    /// </summary>
     IColumnInfo CreatedBy { get; set; }
 
     /// <summary>

--- a/pengdows.crud.abstractions/ITransactionContext.cs
+++ b/pengdows.crud.abstractions/ITransactionContext.cs
@@ -7,17 +7,50 @@ using System.Data;
 namespace pengdows.crud;
 
 /// <summary>
-/// Represents an active database transaction. Nested transactions are not supported; calling
-/// <see cref="IDatabaseContext.BeginTransaction"/> on an existing transaction will throw.
+/// Represents an active database transaction. Nested transactions are not supported;
+/// calling <see cref="IDatabaseContext.BeginTransaction"/> on an existing transaction will throw.
 /// </summary>
 public interface ITransactionContext : IDatabaseContext
 {
+    /// <summary>
+    /// Indicates whether the transaction has been committed.
+    /// </summary>
     bool WasCommitted { get; }
+
+    /// <summary>
+    /// Indicates whether the transaction has been rolled back.
+    /// </summary>
     bool WasRolledBack { get; }
+
+    /// <summary>
+    /// True once the transaction has completed, either through commit or rollback.
+    /// </summary>
     bool IsCompleted { get; }
+
+    /// <summary>
+    /// Isolation level of the active transaction.
+    /// </summary>
     IsolationLevel IsolationLevel { get; }
+
+    /// <summary>
+    /// Commits the transaction.
+    /// </summary>
     void Commit();
+
+    /// <summary>
+    /// Rolls back the transaction.
+    /// </summary>
     void Rollback();
+
+    /// <summary>
+    /// Creates a named savepoint within the transaction scope.
+    /// </summary>
+    /// <param name="name">Savepoint identifier.</param>
     Task SavepointAsync(string name);
+
+    /// <summary>
+    /// Rolls back the transaction to the specified savepoint.
+    /// </summary>
+    /// <param name="name">Savepoint identifier.</param>
     Task RollbackToSavepointAsync(string name);
 }

--- a/pengdows.crud.abstractions/ITypeMapRegistry.cs
+++ b/pengdows.crud.abstractions/ITypeMapRegistry.cs
@@ -1,6 +1,14 @@
 namespace pengdows.crud;
 
+/// <summary>
+/// Provides access to mapping metadata for entity types.
+/// </summary>
 public interface ITypeMapRegistry
 {
+    /// <summary>
+    /// Retrieves table information for the specified entity type.
+    /// </summary>
+    /// <typeparam name="T">Entity type to inspect.</typeparam>
+    /// <returns>Table metadata for the entity.</returns>
     ITableInfo GetTableInfo<T>();
 }

--- a/pengdows.crud.abstractions/configuration/IDbProviderLoader.cs
+++ b/pengdows.crud.abstractions/configuration/IDbProviderLoader.cs
@@ -6,7 +6,14 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace pengdows.crud.configuration;
 
+/// <summary>
+/// Loads and registers database providers with the application service container.
+/// </summary>
 public interface IDbProviderLoader
 {
+    /// <summary>
+    /// Adds provider-specific services to the supplied collection.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
     void LoadAndRegisterProviders(IServiceCollection services);
 }

--- a/pengdows.crud.abstractions/dialects/IDatabaseProductInfo.cs
+++ b/pengdows.crud.abstractions/dialects/IDatabaseProductInfo.cs
@@ -1,12 +1,39 @@
+#region
+
+using System;
 using pengdows.crud.enums;
+
+#endregion
 
 namespace pengdows.crud.dialects;
 
+/// <summary>
+/// Describes product information discovered from a database connection.
+/// </summary>
 public interface IDatabaseProductInfo
 {
+    /// <summary>
+    /// Friendly name of the database product.
+    /// </summary>
     string ProductName { get; set; }
+
+    /// <summary>
+    /// Raw version string reported by the database.
+    /// </summary>
     string ProductVersion { get; set; }
+
+    /// <summary>
+    /// Parsed representation of <see cref="ProductVersion"/>, when available.
+    /// </summary>
     Version? ParsedVersion { get; set; }
+
+    /// <summary>
+    /// Detected database type.
+    /// </summary>
     SupportedDatabase DatabaseType { get; set; }
+
+    /// <summary>
+    /// Highest SQL standard level the database claims to comply with.
+    /// </summary>
     SqlStandardLevel StandardCompliance { get; set; }
 }

--- a/pengdows.crud.abstractions/dialects/ISqlDialect.cs
+++ b/pengdows.crud.abstractions/dialects/ISqlDialect.cs
@@ -6,6 +6,9 @@ using pengdows.crud.wrappers;
 
 namespace pengdows.crud.dialects;
 
+/// <summary>
+/// Provides database-specific SQL dialect behaviors and capability information.
+/// </summary>
 public interface ISqlDialect
 {
     /// <summary>
@@ -18,74 +21,345 @@ public interface ISqlDialect
     /// </summary>
     bool IsInitialized { get; }
 
+    /// <summary>
+    /// Type of database detected from the connected server.
+    /// </summary>
     SupportedDatabase DatabaseType { get; }
+
+    /// <summary>
+    /// Marker prefix used for positional parameters.
+    /// </summary>
     string ParameterMarker { get; }
+
+    /// <summary>
+    /// Retrieves the parameter marker for a specific ordinal position.
+    /// </summary>
+    /// <param name="ordinal">Position of the parameter in the command.</param>
+    /// <returns>Properly formatted parameter marker.</returns>
     string ParameterMarkerAt(int ordinal);
+
+    /// <summary>
+    /// True when the dialect supports named parameters.
+    /// </summary>
     bool SupportsNamedParameters { get; }
+
+    /// <summary>
+    /// Maximum number of parameters allowed in a single command.
+    /// </summary>
     int MaxParameterLimit { get; }
+
+    /// <summary>
+    /// Maximum permitted length for parameter names.
+    /// </summary>
     int ParameterNameMaxLength { get; }
+
+    /// <summary>
+    /// How stored procedure calls must be wrapped for this dialect.
+    /// </summary>
     ProcWrappingStyle ProcWrappingStyle { get; }
 
     /// <summary>
-    /// The highest SQL standard level this database/version supports
+    /// The highest SQL standard level this database/version supports.
     /// </summary>
     SqlStandardLevel MaxSupportedStandard { get; }
 
+    /// <summary>
+    /// Opening quote used for identifiers.
+    /// </summary>
     string QuotePrefix { get; }
+
+    /// <summary>
+    /// Closing quote used for identifiers.
+    /// </summary>
     string QuoteSuffix { get; }
+
+    /// <summary>
+    /// Separator used when composing multi-part identifiers.
+    /// </summary>
     string CompositeIdentifierSeparator { get; }
+
+    /// <summary>
+    /// True when statements should be prepared prior to execution.
+    /// </summary>
     bool PrepareStatements { get; }
+
+    /// <summary>
+    /// Regular expression describing valid parameter names.
+    /// </summary>
     Regex ParameterNamePattern { get; }
+
+    /// <summary>
+    /// Indicates support for integrity constraints such as foreign keys.
+    /// </summary>
     bool SupportsIntegrityConstraints { get; }
+
+    /// <summary>
+    /// True when the dialect supports join operations.
+    /// </summary>
     bool SupportsJoins { get; }
+
+    /// <summary>
+    /// True when outer join syntax is supported.
+    /// </summary>
     bool SupportsOuterJoins { get; }
+
+    /// <summary>
+    /// Indicates support for subquery expressions.
+    /// </summary>
     bool SupportsSubqueries { get; }
+
+    /// <summary>
+    /// True when UNION operations are supported.
+    /// </summary>
     bool SupportsUnion { get; }
+
+    /// <summary>
+    /// Indicates whether user-defined types are available.
+    /// </summary>
     bool SupportsUserDefinedTypes { get; }
+
+    /// <summary>
+    /// True when array column types are supported.
+    /// </summary>
     bool SupportsArrayTypes { get; }
+
+    /// <summary>
+    /// Indicates support for regular expression functions.
+    /// </summary>
     bool SupportsRegularExpressions { get; }
+
+    /// <summary>
+    /// True when the dialect supports the SQL MERGE statement.
+    /// </summary>
     bool SupportsMerge { get; }
+
+    /// <summary>
+    /// Indicates native XML type support.
+    /// </summary>
     bool SupportsXmlTypes { get; }
+
+    /// <summary>
+    /// True when window function syntax is available.
+    /// </summary>
     bool SupportsWindowFunctions { get; }
+
+    /// <summary>
+    /// Indicates support for common table expressions.
+    /// </summary>
     bool SupportsCommonTableExpressions { get; }
+
+    /// <summary>
+    /// True when INSTEAD OF triggers are supported.
+    /// </summary>
     bool SupportsInsteadOfTriggers { get; }
+
+    /// <summary>
+    /// Indicates support for TRUNCATE TABLE commands.
+    /// </summary>
     bool SupportsTruncateTable { get; }
+
+    /// <summary>
+    /// True when temporal table features are available.
+    /// </summary>
     bool SupportsTemporalData { get; }
+
+    /// <summary>
+    /// Indicates enhanced window function support.
+    /// </summary>
     bool SupportsEnhancedWindowFunctions { get; }
+
+    /// <summary>
+    /// True when native JSON column types are supported.
+    /// </summary>
     bool SupportsJsonTypes { get; }
+
+    /// <summary>
+    /// Indicates support for ROW PATTERN MATCHING features.
+    /// </summary>
     bool SupportsRowPatternMatching { get; }
+
+    /// <summary>
+    /// True when multidimensional array types are supported.
+    /// </summary>
     bool SupportsMultidimensionalArrays { get; }
+
+    /// <summary>
+    /// Indicates support for property graph queries.
+    /// </summary>
     bool SupportsPropertyGraphQueries { get; }
+
+    /// <summary>
+    /// True when INSERT ... ON CONFLICT syntax is available.
+    /// </summary>
     bool SupportsInsertOnConflict { get; }
+
+    /// <summary>
+    /// Indicates support for ON DUPLICATE KEY syntax.
+    /// </summary>
     bool SupportsOnDuplicateKey { get; }
+
+    /// <summary>
+    /// True when savepoint statements are supported.
+    /// </summary>
     bool SupportsSavepoints { get; }
+
+    /// <summary>
+    /// Indicates whether stored procedure parameter names must match exactly.
+    /// </summary>
     bool RequiresStoredProcParameterNameMatch { get; }
+
+    /// <summary>
+    /// True when the dialect supports namespaces or schemas.
+    /// </summary>
     bool SupportsNamespaces { get; }
+
+    /// <summary>
+    /// True when this dialect acts as a fallback with limited capabilities.
+    /// </summary>
     bool IsFallbackDialect { get; }
+
+    /// <summary>
+    /// Provides a human-readable warning describing compatibility issues.
+    /// </summary>
+    /// <returns>Warning message for the current dialect.</returns>
     string GetCompatibilityWarning();
+
+    /// <summary>
+    /// Indicates whether modern SQL features can be used safely.
+    /// </summary>
     bool CanUseModernFeatures { get; }
+
+    /// <summary>
+    /// True when the dialect has basic compatibility with CRUD operations.
+    /// </summary>
     bool HasBasicCompatibility { get; }
+
+    /// <summary>
+    /// Wraps an object name with the dialect's quoting strategy.
+    /// </summary>
+    /// <param name="name">Name to wrap.</param>
+    /// <returns>Quoted identifier.</returns>
     string WrapObjectName(string name);
+
+    /// <summary>
+    /// Formats a parameter name according to dialect rules.
+    /// </summary>
+    /// <param name="parameterName">Unformatted parameter name.</param>
+    /// <returns>Formatted parameter name.</returns>
     string MakeParameterName(string parameterName);
+
+    /// <summary>
+    /// Formats a parameter name based on the provided parameter object.
+    /// </summary>
+    /// <param name="dbParameter">Parameter to name.</param>
+    /// <returns>Formatted parameter name.</returns>
     string MakeParameterName(DbParameter dbParameter);
+
+    /// <summary>
+    /// Produces the column expression used for upsert operations.
+    /// </summary>
+    /// <param name="columnName">Column being inserted or updated.</param>
+    /// <returns>Column expression respecting dialect conventions.</returns>
     string UpsertIncomingColumn(string columnName);
+
+    /// <summary>
+    /// Creates a parameter with the specified name, type, and value.
+    /// </summary>
+    /// <typeparam name="T">Parameter value type.</typeparam>
+    /// <param name="name">Parameter name or null for positional parameters.</param>
+    /// <param name="type">Database type of the parameter.</param>
+    /// <param name="value">Value to assign.</param>
+    /// <returns>Configured database parameter.</returns>
     DbParameter CreateDbParameter<T>(string? name, DbType type, T value);
+
+    /// <summary>
+    /// Creates a parameter without specifying a name.
+    /// </summary>
+    /// <typeparam name="T">Parameter value type.</typeparam>
+    /// <param name="type">Database type of the parameter.</param>
+    /// <param name="value">Value to assign.</param>
+    /// <returns>Configured database parameter.</returns>
     DbParameter CreateDbParameter<T>(DbType type, T value);
+
+    /// <summary>
+    /// Returns the query used to fetch the database version.
+    /// </summary>
+    /// <returns>SQL text to retrieve version information.</returns>
     string GetVersionQuery();
+
+    /// <summary>
+    /// Reads the database version from the connection.
+    /// </summary>
+    /// <param name="connection">Connection to inspect.</param>
+    /// <returns>Version string reported by the database.</returns>
     string GetDatabaseVersion(ITrackedConnection connection);
+
+    /// <summary>
+    /// Retrieves the data source information schema as a <see cref="DataTable"/>.
+    /// </summary>
+    /// <param name="connection">Connection to query.</param>
+    /// <returns>Schema information.</returns>
     DataTable GetDataSourceInformationSchema(ITrackedConnection connection);
+
+    /// <summary>
+    /// Returns dialect-specific session settings to apply to a connection.
+    /// </summary>
+    /// <returns>Command text configuring session options.</returns>
     string GetConnectionSessionSettings();
+
+    /// <summary>
+    /// Applies session settings to the provided connection.
+    /// </summary>
+    /// <param name="connection">Connection to configure.</param>
     void ApplyConnectionSettings(IDbConnection connection);
+
+    /// <summary>
+    /// Determines whether READ_COMMITTED_SNAPSHOT is enabled.
+    /// </summary>
+    /// <param name="connection">Connection to check.</param>
+    /// <returns>True if the snapshot isolation is on.</returns>
     bool IsReadCommittedSnapshotOn(ITrackedConnection connection);
+
+    /// <summary>
+    /// Determines whether the given exception represents a unique constraint violation.
+    /// </summary>
+    /// <param name="ex">Exception to inspect.</param>
+    /// <returns>True if the exception indicates a unique key violation.</returns>
     bool IsUniqueViolation(DbException ex);
 
     /// <summary>
-    /// Detects database product information from the connection
+    /// Detects database product information from the connection.
     /// </summary>
+    /// <param name="connection">Connection to interrogate.</param>
+    /// <returns>Discovered product information.</returns>
     Task<IDatabaseProductInfo> DetectDatabaseInfoAsync(ITrackedConnection connection);
 
+    /// <summary>
+    /// Synchronously detects database product information from the connection.
+    /// </summary>
+    /// <param name="connection">Connection to interrogate.</param>
+    /// <returns>Discovered product information.</returns>
     IDatabaseProductInfo DetectDatabaseInfo(ITrackedConnection connection);
+
+    /// <summary>
+    /// Parses a raw version string into a <see cref="Version"/> instance.
+    /// </summary>
+    /// <param name="versionString">Version string reported by the database.</param>
+    /// <returns>Parsed version or null when parsing fails.</returns>
     Version? ParseVersion(string versionString);
+
+    /// <summary>
+    /// Retrieves the major version number from the version string.
+    /// </summary>
+    /// <param name="versionString">Version string reported by the database.</param>
+    /// <returns>Major version or null if unavailable.</returns>
     int? GetMajorVersion(string versionString);
+
+    /// <summary>
+    /// Generates a random identifier respecting name length limits.
+    /// </summary>
+    /// <param name="length">Requested length of the name.</param>
+    /// <param name="parameterNameMaxLength">Maximum allowed name length.</param>
+    /// <returns>Randomly generated name.</returns>
     string GenerateRandomName(int length, int parameterNameMaxLength);
 }

--- a/pengdows.crud.abstractions/infrastructure/ISafeAsyncDisposableBase.cs
+++ b/pengdows.crud.abstractions/infrastructure/ISafeAsyncDisposableBase.cs
@@ -1,6 +1,18 @@
+#region
+
+using System;
+
+#endregion
+
 namespace pengdows.crud.infrastructure;
 
+/// <summary>
+/// Base interface for objects that can be disposed synchronously or asynchronously.
+/// </summary>
 public interface ISafeAsyncDisposableBase : IAsyncDisposable, IDisposable
 {
+    /// <summary>
+    /// Indicates whether the instance has already been disposed.
+    /// </summary>
     public bool IsDisposed { get; }
 }

--- a/pengdows.crud.abstractions/isolation/IIsolationResolver.cs
+++ b/pengdows.crud.abstractions/isolation/IIsolationResolver.cs
@@ -1,5 +1,6 @@
 #region
 
+using System.Collections.Generic;
 using System.Data;
 using pengdows.crud.enums;
 
@@ -7,9 +8,23 @@ using pengdows.crud.enums;
 
 namespace pengdows.crud.isolation;
 
+/// <summary>
+/// Resolves supported isolation levels and validates requested levels.
+/// </summary>
 public interface IIsolationResolver
 {
+    /// <summary>
+    /// Maps an <see cref="IsolationProfile"/> to a concrete <see cref="IsolationLevel"/>.
+    /// </summary>
     IsolationLevel Resolve(IsolationProfile profile);
+
+    /// <summary>
+    /// Validates that the supplied isolation level is supported.
+    /// </summary>
     void Validate(IsolationLevel level);
+
+    /// <summary>
+    /// Returns the set of isolation levels supported by this resolver.
+    /// </summary>
     IReadOnlySet<IsolationLevel> GetSupportedLevels();
 }

--- a/pengdows.crud.abstractions/tenant/ITenantConnectionResolver.cs
+++ b/pengdows.crud.abstractions/tenant/ITenantConnectionResolver.cs
@@ -6,7 +6,14 @@ using pengdows.crud.configuration;
 
 namespace pengdows.crud.tenant;
 
+/// <summary>
+/// Resolves database context configuration information for tenants.
+/// </summary>
 public interface ITenantConnectionResolver
 {
+    /// <summary>
+    /// Retrieves configuration for the specified tenant identifier.
+    /// </summary>
+    /// <param name="tenant">Tenant identifier.</param>
     IDatabaseContextConfiguration GetDatabaseContextConfiguration(string tenant);
 }

--- a/pengdows.crud.abstractions/tenant/ITenantContextRegistry.cs
+++ b/pengdows.crud.abstractions/tenant/ITenantContextRegistry.cs
@@ -1,6 +1,20 @@
+#region
+
+using pengdows.crud;
+
+#endregion
+
 namespace pengdows.crud.tenant;
 
+/// <summary>
+/// Provides access to <see cref="IDatabaseContext"/> instances for tenants.
+/// </summary>
 public interface ITenantContextRegistry
 {
+    /// <summary>
+    /// Retrieves a database context for the specified tenant.
+    /// </summary>
+    /// <param name="tenant">Tenant identifier.</param>
+    /// <returns>The associated database context.</returns>
     public IDatabaseContext GetContext(string tenant);
 }

--- a/pengdows.crud.abstractions/tenant/ITenantInformation.cs
+++ b/pengdows.crud.abstractions/tenant/ITenantInformation.cs
@@ -6,8 +6,18 @@ using pengdows.crud.enums;
 
 namespace pengdows.crud.tenant;
 
+/// <summary>
+/// Provides tenant-specific database connection information.
+/// </summary>
 public interface ITenantInformation
 {
+    /// <summary>
+    /// Database type used by the tenant.
+    /// </summary>
     SupportedDatabase DatabaseType { get; }
+
+    /// <summary>
+    /// Connection string for the tenant database.
+    /// </summary>
     string ConnectionString { get; }
 }

--- a/pengdows.crud.abstractions/threading/ILockerAsync.cs
+++ b/pengdows.crud.abstractions/threading/ILockerAsync.cs
@@ -1,8 +1,27 @@
+#region
+
+using System;
+using System.Threading;
+
+#endregion
+
 namespace pengdows.crud.threading;
 
+/// <summary>
+/// Provides asynchronous locking semantics.
+/// </summary>
 public interface ILockerAsync : IAsyncDisposable
 {
+    /// <summary>
+    /// Acquires the lock, awaiting if necessary.
+    /// </summary>
     Task LockAsync(CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Attempts to acquire the lock within the specified timeout.
+    /// </summary>
+    /// <param name="timeout">How long to wait for the lock.</param>
+    /// <param name="cancellationToken">Token used to cancel the wait.</param>
+    /// <returns>True if the lock was acquired.</returns>
     Task<bool> TryLockAsync(TimeSpan timeout, CancellationToken cancellationToken = default);
 }

--- a/pengdows.crud.abstractions/wrappers/ITrackedConnection.cs
+++ b/pengdows.crud.abstractions/wrappers/ITrackedConnection.cs
@@ -1,6 +1,7 @@
 #region
 
 using System.Data;
+using System.Threading;
 using pengdows.crud.threading;
 #pragma warning disable CS0108, CS0114
 
@@ -8,9 +9,12 @@ using pengdows.crud.threading;
 
 namespace pengdows.crud.wrappers;
 
+/// <summary>
+/// Represents a connection that tracks usage and exposes additional helpers such as locking.
+/// </summary>
 public interface ITrackedConnection : IDbConnection
 {
-    string ConnectionString { get; set; }  
+    string ConnectionString { get; set; }
     int ConnectionTimeout { get; }
     string Database { get; }
     ConnectionState State { get; }
@@ -27,6 +31,13 @@ public interface ITrackedConnection : IDbConnection
     void Dispose();
     ValueTask DisposeAsync();
 
+    /// <summary>
+    /// Provides an asynchronous lock tied to this connection.
+    /// </summary>
     ILockerAsync GetLock();
+
+    /// <summary>
+    /// Retrieves schema information for the current connection.
+    /// </summary>
     DataTable GetSchema();
 }

--- a/pengdows.crud.abstractions/wrappers/ITrackedReader.cs
+++ b/pengdows.crud.abstractions/wrappers/ITrackedReader.cs
@@ -6,7 +6,14 @@ using System.Data;
 
 namespace pengdows.crud.wrappers;
 
+/// <summary>
+/// Represents a data reader that tracks its owning connection for proper disposal.
+/// </summary>
 public interface ITrackedReader : IDataReader, IAsyncDisposable
 {
+    /// <summary>
+    /// Advances the reader to the next record asynchronously.
+    /// </summary>
+    /// <returns>True if another record is available.</returns>
     Task<bool> ReadAsync();
 }

--- a/pengdows.crud/IContextIdentity.cs
+++ b/pengdows.crud/IContextIdentity.cs
@@ -1,6 +1,18 @@
+#region
+
+using System;
+
+#endregion
+
 namespace pengdows.crud;
 
-public interface IContextIdentity
+/// <summary>
+/// Represents an immutable identifier for the current execution context.
+/// </summary>
+internal interface IContextIdentity
 {
+    /// <summary>
+    /// Identifier for the root request or operation.
+    /// </summary>
     Guid RootId { get; }
 }

--- a/pengdows.crud/ISqlDialectProvider.cs
+++ b/pengdows.crud/ISqlDialectProvider.cs
@@ -1,6 +1,12 @@
 namespace pengdows.crud.dialects;
 
+/// <summary>
+/// Provides access to the active <see cref="ISqlDialect"/> instance.
+/// </summary>
 internal interface ISqlDialectProvider
 {
+    /// <summary>
+    /// Gets the SQL dialect in use.
+    /// </summary>
     ISqlDialect Dialect { get; }
 }

--- a/pengdows.crud/TableInfo.cs
+++ b/pengdows.crud/TableInfo.cs
@@ -7,7 +7,10 @@ public class TableInfo : ITableInfo
     public Dictionary<string, IColumnInfo> Columns { get; } = new(StringComparer.OrdinalIgnoreCase);
     public string Schema { get; set; }
     public string Name { get; set; }
+
+    /// <inheritdoc />
     public IColumnInfo Id { get; set; }
+
     public IColumnInfo Version { get; set; }
     public IColumnInfo LastUpdatedBy { get; set; }
     public IColumnInfo LastUpdatedOn { get; set; }

--- a/pengdows.crud/connection/IConnectionStrategy.cs
+++ b/pengdows.crud/connection/IConnectionStrategy.cs
@@ -4,9 +4,28 @@ using pengdows.crud.wrappers;
 
 namespace pengdows.crud.connection;
 
+/// <summary>
+/// Manages acquisition and release of tracked database connections.
+/// </summary>
 internal interface IConnectionStrategy : ISafeAsyncDisposableBase
 {
+    /// <summary>
+    /// Obtains a connection for the given execution type.
+    /// </summary>
+    /// <param name="executionType">Requested execution type.</param>
+    /// <param name="isShared">Indicates whether the connection can be shared.</param>
+    /// <returns>The acquired tracked connection.</returns>
     ITrackedConnection GetConnection(ExecutionType executionType, bool isShared = false);
+
+    /// <summary>
+    /// Releases a previously obtained connection.
+    /// </summary>
+    /// <param name="connection">The connection to release.</param>
     void ReleaseConnection(ITrackedConnection? connection);
+
+    /// <summary>
+    /// Releases a connection asynchronously.
+    /// </summary>
+    /// <param name="connection">The connection to release.</param>
     ValueTask ReleaseConnectionAsync(ITrackedConnection? connection);
 }

--- a/pengdows.crud/pengdows.crud.csproj
+++ b/pengdows.crud/pengdows.crud.csproj
@@ -42,6 +42,7 @@
     </ItemGroup>
     <ItemGroup>
         <InternalsVisibleTo Include="pengdows.crud.Tests" />
+        <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
     </ItemGroup>
 
 </Project>

--- a/pengdows.crud/tenant/ITenantConfiguration.cs
+++ b/pengdows.crud/tenant/ITenantConfiguration.cs
@@ -1,5 +1,8 @@
 namespace pengdows.crud.tenant;
 
+/// <summary>
+/// Marker interface for tenant configuration types.
+/// </summary>
 public interface ITenantConfiguration
 {
 }


### PR DESCRIPTION
## Summary
- document audit, tenant, and connection interfaces across projects
- clarify column metadata and transaction abstractions
- document SQL dialect capabilities and feature support
- clarify Id column pseudo key documentation
- clarify pseudo key terminology in entity helpers
- internalize context identity validation

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ad84c9193c83258b0cd0706126a4f2