### PR TITLE
Cache common column lists and queries

### DIFF
--- a/pengdows.crud.Tests/ColumnListCacheTests.cs
+++ b/pengdows.crud.Tests/ColumnListCacheTests.cs
@@ -1,0 +1,107 @@
+#region
+using System.Collections.Generic;
+using System.Data;
+using System.Reflection;
+using pengdows.crud;
+using pengdows.crud.attributes;
+using Xunit;
+#endregion
+
+namespace pengdows.crud.Tests;
+
+public class ColumnListCacheTests : SqlLiteContextTestBase
+{
+    [Fact]
+    public void GetInsertableColumns_CachesList()
+    {
+        TypeMap.Register<CacheTestEntity>();
+        var helper = new EntityHelper<CacheTestEntity, int>(Context);
+        var method = typeof(EntityHelper<CacheTestEntity, int>).GetMethod("GetCachedInsertableColumns", BindingFlags.NonPublic | BindingFlags.Instance);
+        var first = (IReadOnlyList<IColumnInfo>)method!.Invoke(helper, null)!;
+        var second = (IReadOnlyList<IColumnInfo>)method.Invoke(helper, null)!;
+        Assert.Contains(first, c => c.Name == "Name");
+        Assert.DoesNotContain(first, c => c.Name == "NoInsert" || c.Name == "Id");
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void GetInsertableColumns_NoInsertables_ReturnsEmpty()
+    {
+        TypeMap.Register<OnlyNonInsertEntity>();
+        var helper = new EntityHelper<OnlyNonInsertEntity, int>(Context);
+        var method = typeof(EntityHelper<OnlyNonInsertEntity, int>).GetMethod("GetCachedInsertableColumns", BindingFlags.NonPublic | BindingFlags.Instance);
+        var first = (IReadOnlyList<IColumnInfo>)method!.Invoke(helper, null)!;
+        var second = (IReadOnlyList<IColumnInfo>)method.Invoke(helper, null)!;
+        Assert.Empty(first);
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void GetUpdatableColumns_CachesList()
+    {
+        TypeMap.Register<CacheTestEntity>();
+        var helper = new EntityHelper<CacheTestEntity, int>(Context);
+        var method = typeof(EntityHelper<CacheTestEntity, int>).GetMethod("GetCachedUpdatableColumns", BindingFlags.NonPublic | BindingFlags.Instance);
+        var first = (IReadOnlyList<IColumnInfo>)method!.Invoke(helper, null)!;
+        var second = (IReadOnlyList<IColumnInfo>)method.Invoke(helper, null)!;
+        Assert.Contains(first, c => c.Name == "Name");
+        Assert.Contains(first, c => c.Name == "NoInsert");
+        Assert.DoesNotContain(first, c => c.Name == "Immutable" || c.Name == "Id" || c.Name == "Version");
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void GetUpdatableColumns_NoUpdatables_ReturnsEmpty()
+    {
+        TypeMap.Register<OnlyNonUpdateEntity>();
+        var helper = new EntityHelper<OnlyNonUpdateEntity, int>(Context);
+        var method = typeof(EntityHelper<OnlyNonUpdateEntity, int>).GetMethod("GetCachedUpdatableColumns", BindingFlags.NonPublic | BindingFlags.Instance);
+        var first = (IReadOnlyList<IColumnInfo>)method!.Invoke(helper, null)!;
+        var second = (IReadOnlyList<IColumnInfo>)method.Invoke(helper, null)!;
+        Assert.Empty(first);
+        Assert.Same(first, second);
+    }
+    [Table("CacheTest")]
+    private class CacheTestEntity
+    {
+        [Id(writable: false)]
+        [Column("Id", DbType.Int32)]
+        public int Id { get; set; }
+
+        [Column("Name", DbType.String)]
+        public string? Name { get; set; }
+
+        [Column("Immutable", DbType.String)]
+        [NonUpdateable]
+        public string? Immutable { get; set; }
+
+        [Column("NoInsert", DbType.String)]
+        [NonInsertable]
+        public string? NoInsert { get; set; }
+
+        [Version]
+        [Column("Version", DbType.Int32)]
+        public int Version { get; set; }
+    }
+
+    [Table("OnlyNonInsert")]
+    private class OnlyNonInsertEntity
+    {
+        [Id(writable: false)]
+        [Column("Id", DbType.Int32)]
+        [NonInsertable]
+        public int Id { get; set; }
+    }
+
+    [Table("OnlyNonUpdate")]
+    private class OnlyNonUpdateEntity
+    {
+        [Id]
+        [Column("Id", DbType.Int32)]
+        public int Id { get; set; }
+
+        [Column("NoUpdate", DbType.String)]
+        [NonUpdateable]
+        public string? NoUpdate { get; set; }
+    }
+}

--- a/pengdows.crud.Tests/DatabaseContextTests.cs
+++ b/pengdows.crud.Tests/DatabaseContextTests.cs
@@ -198,9 +198,13 @@ public class DatabaseContextTests
         var context = new DatabaseContext($"Data Source=test;EmulatedProduct={product}", factory);
         var preamble = context.SessionSettingsPreamble;
         if (expectSettings)
+        {
             Assert.False(string.IsNullOrWhiteSpace(preamble));
+        }
         else
+        {
             Assert.True(string.IsNullOrWhiteSpace(preamble));
+        }
     }
 
     [Fact]

--- a/pengdows.crud.Tests/GetDateTimeTypeTests.cs
+++ b/pengdows.crud.Tests/GetDateTimeTypeTests.cs
@@ -1,0 +1,25 @@
+using System.Reflection;
+using pengdows.crud.enums;
+using testbed;
+using Xunit;
+
+public class GetDateTimeTypeTests
+{
+    [Fact]
+    public void ReturnsTimestampWithTimeZone_ForPostgreSql()
+    {
+        var method = typeof(TestProvider).GetMethod("GetDateTimeType", BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        var result = (string)method!.Invoke(null, new object[] { SupportedDatabase.PostgreSql })!;
+        Assert.Equal("TIMESTAMP WITH TIME ZONE", result);
+    }
+
+    [Fact]
+    public void ReturnsDatetime_ForNonPostgres()
+    {
+        var method = typeof(TestProvider).GetMethod("GetDateTimeType", BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+        var result = (string)method!.Invoke(null, new object[] { SupportedDatabase.Sqlite })!;
+        Assert.Equal("DATETIME", result);
+    }
+}

--- a/pengdows.crud.Tests/GetDateTimeTypeTests.cs
+++ b/pengdows.crud.Tests/GetDateTimeTypeTests.cs
@@ -3,6 +3,7 @@ using pengdows.crud.enums;
 using testbed;
 using Xunit;
 
+namespace pengdows.crud.Tests;
 public class GetDateTimeTypeTests
 {
     [Fact]

--- a/pengdows.crud.Tests/PrimaryKeyCacheTests.cs
+++ b/pengdows.crud.Tests/PrimaryKeyCacheTests.cs
@@ -1,0 +1,53 @@
+#region
+using System.Data;
+using System.Reflection;
+using pengdows.crud;
+using pengdows.crud.attributes;
+using Xunit;
+#endregion
+
+namespace pengdows.crud.Tests;
+
+public class PrimaryKeyCacheTests : SqlLiteContextTestBase
+{
+    [Fact]
+    public void PrimaryKeys_CachesList()
+    {
+        TypeMap.Register<CompositeKeyEntity>();
+        var info = TypeMap.GetTableInfo<CompositeKeyEntity>();
+        var first = info.PrimaryKeys;
+        var second = info.PrimaryKeys;
+        Assert.Equal(2, first.Count);
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void PrimaryKeys_NoKeys_ReturnsEmpty()
+    {
+        TypeMap.Register<IdOnlyEntity>();
+        var info = TypeMap.GetTableInfo<IdOnlyEntity>();
+        var first = info.PrimaryKeys;
+        var second = info.PrimaryKeys;
+        Assert.Empty(first);
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void GetPrimaryKeys_NoKeys_Throws()
+    {
+        TypeMap.Register<IdOnlyEntity>();
+        var helper = new EntityHelper<IdOnlyEntity, int>(Context);
+        var method = typeof(EntityHelper<IdOnlyEntity, int>).GetMethod("GetPrimaryKeys", BindingFlags.NonPublic | BindingFlags.Instance);
+        var ex = Assert.Throws<TargetInvocationException>(() => method!.Invoke(helper, null));
+        Assert.Contains("No primary keys found", ex.InnerException?.Message);
+    }
+
+    [Table("IdOnly")]
+    private class IdOnlyEntity
+    {
+        [Id]
+        [Column("Id", DbType.Int32)]
+        public int Id { get; set; }
+    }
+}
+

--- a/pengdows.crud.Tests/QueryCacheTests.cs
+++ b/pengdows.crud.Tests/QueryCacheTests.cs
@@ -1,0 +1,168 @@
+#region
+using System.Collections.Generic;
+using System.Data;
+using System.Reflection;
+using pengdows.crud;
+using pengdows.crud.attributes;
+using Xunit;
+#endregion
+
+namespace pengdows.crud.Tests;
+
+public class QueryCacheTests : SqlLiteContextTestBase
+{
+    [Fact]
+    public void BuildDelete_UsesCachedSql()
+    {
+        TypeMap.Register<CacheEntity>();
+        var helper = new EntityHelper<CacheEntity, int>(Context);
+
+        helper.BuildDelete(1);
+        var cache = GetQueryCache(helper);
+        var first = cache["DeleteById"];
+
+        helper.BuildDelete(2);
+        var second = cache["DeleteById"];
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void BuildDelete_CacheScopedPerInstance()
+    {
+        TypeMap.Register<CacheEntity>();
+        var helper1 = new EntityHelper<CacheEntity, int>(Context);
+        helper1.BuildDelete(1);
+        var cache1 = GetQueryCache(helper1);
+        Assert.True(cache1.ContainsKey("DeleteById"));
+
+        var helper2 = new EntityHelper<CacheEntity, int>(Context);
+        var cache2 = GetQueryCache(helper2);
+        Assert.False(cache2.ContainsKey("DeleteById"));
+    }
+
+    [Fact]
+    public void BuildBaseRetrieve_CachesPerAlias()
+    {
+        TypeMap.Register<CacheEntity>();
+        var helper = new EntityHelper<CacheEntity, int>(Context);
+
+        helper.BuildBaseRetrieve("a");
+        var cache = GetQueryCache(helper);
+        var first = cache["BaseRetrieve:a"];
+
+        helper.BuildBaseRetrieve("a");
+        var second = cache["BaseRetrieve:a"];
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void BuildBaseRetrieve_DifferentAlias_SeparatesCache()
+    {
+        TypeMap.Register<CacheEntity>();
+        var helper = new EntityHelper<CacheEntity, int>(Context);
+
+        helper.BuildBaseRetrieve("a");
+        helper.BuildBaseRetrieve("b");
+        var cache = GetQueryCache(helper);
+
+        Assert.NotSame(cache["BaseRetrieve:a"], cache["BaseRetrieve:b"]);
+    }
+
+    [Fact]
+    public void BuildWhere_CachesByCount()
+    {
+        TypeMap.Register<CacheEntity>();
+        var helper = new EntityHelper<CacheEntity, int>(Context);
+        var wrapped = Context.WrapObjectName("Id");
+
+        var sc1 = Context.CreateSqlContainer();
+        helper.BuildWhere(wrapped, new[] { 1, 2 }, sc1);
+        var cache = GetQueryCache(helper);
+        var key = $"Where:{wrapped}:2";
+        var first = cache[key];
+
+        var sc2 = Context.CreateSqlContainer();
+        helper.BuildWhere(wrapped, new[] { 3, 4 }, sc2);
+        var second = cache[key];
+
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void BuildWhere_DifferentCount_SeparatesCache()
+    {
+        TypeMap.Register<CacheEntity>();
+        var helper = new EntityHelper<CacheEntity, int>(Context);
+        var wrapped = Context.WrapObjectName("Id");
+
+        var sc1 = Context.CreateSqlContainer();
+        helper.BuildWhere(wrapped, new[] { 1 }, sc1);
+
+        var sc2 = Context.CreateSqlContainer();
+        helper.BuildWhere(wrapped, new[] { 1, 2 }, sc2);
+
+        var cache = GetQueryCache(helper);
+        Assert.NotSame(cache[$"Where:{wrapped}:1"], cache[$"Where:{wrapped}:2"]);
+    }
+
+    [Fact]
+    public void BuildWhere_ReusesParameters_WhenContainerReused()
+    {
+        TypeMap.Register<CacheEntity>();
+        var helper = new EntityHelper<CacheEntity, int>(Context);
+        var wrapped = Context.WrapObjectName("Id");
+
+        var sc = Context.CreateSqlContainer();
+        helper.BuildWhere(wrapped, new[] { 1, 2 }, sc);
+        var countBefore = sc.ParameterCount;
+        var p0 = Context.MakeParameterName("p0");
+        var p1 = Context.MakeParameterName("p1");
+
+        helper.BuildWhere(wrapped, new[] { 3, 4 }, sc);
+
+        Assert.Equal(countBefore, sc.ParameterCount);
+        Assert.Equal(3, sc.GetParameterValue<int>(p0));
+        Assert.Equal(4, sc.GetParameterValue<int>(p1));
+    }
+
+    [Fact]
+    public void BuildWhere_AddsParameters_WhenCountIncreases()
+    {
+        TypeMap.Register<CacheEntity>();
+        var helper = new EntityHelper<CacheEntity, int>(Context);
+        var wrapped = Context.WrapObjectName("Id");
+
+        var sc = Context.CreateSqlContainer();
+        helper.BuildWhere(wrapped, new[] { 1 }, sc);
+        var countBefore = sc.ParameterCount;
+
+        helper.BuildWhere(wrapped, new[] { 2, 3 }, sc);
+
+        var p0 = Context.MakeParameterName("p0");
+        var p1 = Context.MakeParameterName("p1");
+
+        Assert.True(sc.ParameterCount > countBefore);
+        Assert.Equal(2, sc.GetParameterValue<int>(p0));
+        Assert.Equal(3, sc.GetParameterValue<int>(p1));
+    }
+
+    private static Dictionary<string, string> GetQueryCache<TEntity, TId>(EntityHelper<TEntity, TId> helper)
+        where TEntity : class, new()
+    {
+        var field = typeof(EntityHelper<TEntity, TId>).GetField("_queryCache", BindingFlags.NonPublic | BindingFlags.Instance);
+        return (Dictionary<string, string>)field!.GetValue(helper)!;
+    }
+
+    [Table("CacheEntity")]
+    private class CacheEntity
+    {
+        [Id]
+        [Column("Id", DbType.Int32)]
+        public int Id { get; set; }
+
+        [Column("Name", DbType.String)]
+        public string? Name { get; set; }
+    }
+}

--- a/pengdows.crud.Tests/SqlContainerTests.cs
+++ b/pengdows.crud.Tests/SqlContainerTests.cs
@@ -1,6 +1,7 @@
 #region
 
 using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Threading.Tasks;
 using pengdows.crud.enums;
@@ -86,6 +87,82 @@ public class SqlContainerTests : SqlLiteContextTestBase
 
         Assert.False(string.IsNullOrEmpty(param.ParameterName));
         Assert.Equal(1, container.ParameterCount);
+    }
+
+    [Fact]
+    public void SetParameterValue_UpdatesExistingParameter()
+    {
+        var container = Context.CreateSqlContainer();
+        var param = container.AddParameterWithValue(DbType.Int32, 1);
+
+        container.SetParameterValue(param.ParameterName, 5);
+
+        var value = container.GetParameterValue<int>(param.ParameterName);
+        Assert.Equal(5, value);
+    }
+
+    [Fact]
+    public void SetParameterValue_MissingParameter_Throws()
+    {
+        var container = Context.CreateSqlContainer();
+
+        Assert.Throws<KeyNotFoundException>(() => container.SetParameterValue("does_not_exist", 1));
+    }
+
+    [Fact]
+    public void GetParameterValue_ReturnsValue()
+    {
+        var container = Context.CreateSqlContainer();
+        var param = container.AddParameterWithValue(DbType.String, "abc");
+
+        var value = container.GetParameterValue<string>(param.ParameterName);
+        Assert.Equal("abc", value);
+    }
+
+    [Fact]
+    public void GetParameterValue_MissingParameter_Throws()
+    {
+        var container = Context.CreateSqlContainer();
+
+        Assert.Throws<KeyNotFoundException>(() => container.GetParameterValue<int>("missing"));
+    }
+
+    [Fact]
+    public void GetParameterValue_IntToString_Converts()
+    {
+        var container = Context.CreateSqlContainer();
+        var param = container.AddParameterWithValue(DbType.Int32, 1);
+
+        var value = container.GetParameterValue<string>(param.ParameterName);
+
+        Assert.Equal("1", value);
+    }
+
+    [Fact]
+    public void GetParameterValue_InvalidConversion_Throws()
+    {
+        var container = Context.CreateSqlContainer();
+        var param = container.AddParameterWithValue(DbType.String, "abc");
+
+        Assert.Throws<InvalidCastException>(() => container.GetParameterValue<int>(param.ParameterName));
+    }
+
+    [Fact]
+    public void GetParameterValue_Object_ReturnsValue()
+    {
+        var container = Context.CreateSqlContainer();
+        var param = container.AddParameterWithValue(DbType.Int32, 2);
+
+        var value = container.GetParameterValue(param.ParameterName);
+        Assert.Equal(2, value);
+    }
+
+    [Fact]
+    public void GetParameterValue_Object_MissingParameter_Throws()
+    {
+        var container = Context.CreateSqlContainer();
+
+        Assert.Throws<KeyNotFoundException>(() => container.GetParameterValue("missing"));
     }
 
     [Fact]

--- a/pengdows.crud.Tests/TestTableSchemaTests.cs
+++ b/pengdows.crud.Tests/TestTableSchemaTests.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.DependencyInjection;
+using pengdows.crud;
+using testbed;
+using Xunit;
+
+public class TestTableSchemaTests
+{
+    [Fact]
+    public async Task IdColumn_IsPrimaryKey()
+    {
+        var cs = "Data Source=" + Path.GetTempFileName();
+        await using var db = new DatabaseContext(cs, SqliteFactory.Instance, null);
+        var services = new ServiceCollection();
+        services.AddScoped<IAuditValueResolver, StringAuditContextProvider>();
+        var sp = services.BuildServiceProvider();
+        var provider = new TestProvider(db, sp);
+        await provider.CreateTable();
+
+        await using var conn = new SqliteConnection(cs);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "PRAGMA table_info('test_table');";
+        var columns = new Dictionary<string, long>();
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            var name = reader.GetString(1);
+            var pk = reader.GetInt64(5);
+            columns[name] = pk;
+        }
+
+        Assert.Equal(1, columns["id"]);
+    }
+
+    [Fact]
+    public async Task NameColumn_IsNotPrimaryKey()
+    {
+        var cs = "Data Source=" + Path.GetTempFileName();
+        await using var db = new DatabaseContext(cs, SqliteFactory.Instance, null);
+        var services = new ServiceCollection();
+        services.AddScoped<IAuditValueResolver, StringAuditContextProvider>();
+        var sp = services.BuildServiceProvider();
+        var provider = new TestProvider(db, sp);
+        await provider.CreateTable();
+
+        await using var conn = new SqliteConnection(cs);
+        await conn.OpenAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "PRAGMA table_info('test_table');";
+        await using var reader = await cmd.ExecuteReaderAsync();
+        long pkValue = -1;
+        while (await reader.ReadAsync())
+        {
+            var name = reader.GetString(1);
+            if (name == "name")
+            {
+                pkValue = reader.GetInt64(5);
+            }
+        }
+
+        Assert.Equal(0, pkValue);
+    }
+}

--- a/pengdows.crud.Tests/TestTableSchemaTests.cs
+++ b/pengdows.crud.Tests/TestTableSchemaTests.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using pengdows.crud;
 using testbed;
 using Xunit;
-
+namespace pengdows.crud.Tests;
 public class TestTableSchemaTests
 {
     [Fact]

--- a/pengdows.crud.Tests/TypeMapRegistryTests.cs
+++ b/pengdows.crud.Tests/TypeMapRegistryTests.cs
@@ -89,10 +89,12 @@ public class TypeMapRegistryTests
         var registry = new TypeMapRegistry();
         var info = registry.GetTableInfo<OrderedEntity>();
 
-        var columns = info.Columns.Values.OrderBy(c => c.Ordinal).ToList();
-        Assert.Equal(new[] { "A", "B" }, columns.Select(c => c.Name));
+        var columns1 = info.OrderedColumns;
+        var columns2 = info.OrderedColumns;
+        Assert.Same(columns1, columns2);
+        Assert.Equal(new[] { "A", "B" }, columns1.Select(c => c.Name));
 
-        var pks = info.Columns.Values.Where(c => c.IsPrimaryKey).OrderBy(c => c.PkOrder).ToList();
+        var pks = info.PrimaryKeys;
         Assert.Equal(new[] { "A", "B" }, pks.Select(c => c.Name));
     }
 

--- a/pengdows.crud.Tests/UtilsTests.cs
+++ b/pengdows.crud.Tests/UtilsTests.cs
@@ -49,16 +49,22 @@ public class UtilsTests
     {
         var nestedType = containerType.GetNestedType(nestedClassName, BindingFlags.NonPublic | BindingFlags.Public);
         if (nestedType == null)
+        {
             throw new ArgumentException($"Nested class '{nestedClassName}' not found in '{containerType.Name}'.");
+        }
 
         var propInfo = nestedType.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
         if (propInfo == null)
+        {
             throw new ArgumentException($"Property '{propertyName}' not found in '{nestedClassName}'.");
+        }
 
         var attr = propInfo.GetCustomAttribute<TAttribute>();
         if (attr == null)
+        {
             throw new ArgumentException(
                 $"Attribute '{typeof(TAttribute).Name}' not found on property '{propertyName}'.");
+        }
 
         return attr;
     }

--- a/pengdows.crud.abstractions/ISqlContainer.cs
+++ b/pengdows.crud.abstractions/ISqlContainer.cs
@@ -114,6 +114,29 @@ public interface ISqlContainer :ISafeAsyncDisposableBase
     DbParameter AddParameterWithValue<T>(string? name, DbType type, T value);
 
     /// <summary>
+    /// Sets a parameter value for an existing parameter.
+    /// </summary>
+    /// <param name="parameterName">The name of the parameter to update.</param>
+    /// <param name="newValue">The new value to assign.</param>
+    void SetParameterValue(string parameterName, object? newValue);
+
+    /// <summary>
+    /// Retrieves the value of a parameter as an <see cref="object"/>.
+    /// </summary>
+    /// <param name="parameterName">The name of the parameter.</param>
+    /// <returns>The parameter value.</returns>
+    object? GetParameterValue(string parameterName);
+
+    /// <summary>
+    /// Retrieves the value of a parameter and coerces it to the specified type using
+    /// <see cref="TypeCoercionHelper"/>.
+    /// </summary>
+    /// <typeparam name="T">The expected type of the parameter value.</typeparam>
+    /// <param name="parameterName">The name of the parameter.</param>
+    /// <returns>The parameter value cast to <typeparamref name="T"/>.</returns>
+    T GetParameterValue<T>(string parameterName);
+
+    /// <summary>
     /// Executes the current query as a non-query command.
     /// </summary>
     /// <param name="commandType">Type of command to execute.</param>

--- a/pengdows.crud.abstractions/ITableInfo.cs
+++ b/pengdows.crud.abstractions/ITableInfo.cs
@@ -27,6 +27,16 @@ public interface ITableInfo
     Dictionary<string, IColumnInfo> Columns { get; }
 
     /// <summary>
+    /// Columns sorted by their <see cref="IColumnInfo.Ordinal"/>.
+    /// </summary>
+    IReadOnlyList<IColumnInfo> OrderedColumns { get; }
+
+    /// <summary>
+    /// Columns marked with <see cref="IColumnInfo.IsPrimaryKey"/>, ordered by <see cref="IColumnInfo.PkOrder"/>.
+    /// </summary>
+    IReadOnlyList<IColumnInfo> PrimaryKeys { get; }
+
+    /// <summary>
     /// Column representing the pseudo key used to uniquely identify a row.
     /// This <c>Id</c> differs from any business-defined <see cref="IColumnInfo.IsPrimaryKey"/>
     /// columns and should not be mistaken for the primary key.

--- a/pengdows.crud.fakeDb/FakeDbCommand.cs
+++ b/pengdows.crud.fakeDb/FakeDbCommand.cs
@@ -50,7 +50,10 @@ public class FakeDbCommand : DbCommand
     {
         var conn = FakeConnection;
         if (conn != null && conn.NonQueryResults.Count > 0)
+        {
             return conn.NonQueryResults.Dequeue();
+        }
+
         return 1;
     }
 
@@ -61,19 +64,25 @@ public class FakeDbCommand : DbCommand
         {
             // Check for command-text-based result first
             if (!string.IsNullOrEmpty(CommandText) && conn.ScalarResultsByCommand.TryGetValue(CommandText, out var commandResult))
+            {
                 return commandResult;
-            
+            }
+
             // Handle version queries automatically based on emulated product
             if (!string.IsNullOrEmpty(CommandText))
             {
                 var versionResult = GetVersionQueryResult(CommandText, conn.EmulatedProduct);
                 if (versionResult != null)
+                {
                     return versionResult;
+                }
             }
             
             // Fall back to queued results
             if (conn.ScalarResults.Count > 0)
+            {
                 return conn.ScalarResults.Dequeue();
+            }
         }
         return 42;
     }
@@ -119,7 +128,10 @@ public class FakeDbCommand : DbCommand
     {
         var conn = FakeConnection;
         if (conn != null && conn.ReaderResults.Count > 0)
+        {
             return new FakeDbDataReader(conn.ReaderResults.Dequeue());
+        }
+
         return new FakeDbDataReader();
     }
 

--- a/pengdows.crud.fakeDb/FakeParameterCollection.cs
+++ b/pengdows.crud.fakeDb/FakeParameterCollection.cs
@@ -71,7 +71,10 @@ public class FakeParameterCollection : DbParameterCollection
     protected override DbParameter GetParameter(string parameterName)
     {
         var list = _params.Where(p => p.ParameterName == parameterName).ToList();
-        if (list.Count < 1) throw new IndexOutOfRangeException(parameterName);
+        if (list.Count < 1)
+        {
+            throw new IndexOutOfRangeException(parameterName);
+        }
 
         return list[0];
     }

--- a/pengdows.crud/ColumnInfo.cs
+++ b/pengdows.crud/ColumnInfo.cs
@@ -38,11 +38,16 @@ public class ColumnInfo : IColumnInfo
         if (value != null)
         {
             if (EnumType != null)
+            {
                 value = DbType == DbType.String
                     ? value.ToString() // Save enum as string name
                     : Convert.ChangeType(value, Enum.GetUnderlyingType(EnumType)); // Save enum as int
+            }
 
-            if (IsJsonType) value = JsonSerializer.Serialize(value);
+            if (IsJsonType)
+            {
+                value = JsonSerializer.Serialize(value);
+            }
         }
 
         return value;

--- a/pengdows.crud/DataSourceInformation.cs
+++ b/pengdows.crud/DataSourceInformation.cs
@@ -66,8 +66,16 @@ public class DataSourceInformation : IDataSourceInformation
 
     public static async Task<DataSourceInformation> CreateAsync(ITrackedConnection connection, DbProviderFactory factory, ILoggerFactory? loggerFactory = null)
     {
-        if (connection == null) throw new ArgumentNullException(nameof(connection));
-        if (factory == null) throw new ArgumentNullException(nameof(factory));
+        if (connection == null)
+        {
+            throw new ArgumentNullException(nameof(connection));
+        }
+
+        if (factory == null)
+        {
+            throw new ArgumentNullException(nameof(factory));
+        }
+
         loggerFactory ??= NullLoggerFactory.Instance;
 
         if (connection.State != ConnectionState.Open)

--- a/pengdows.crud/DatabaseContext.cs
+++ b/pengdows.crud/DatabaseContext.cs
@@ -383,7 +383,9 @@ public class DatabaseContext : SafeAsyncDisposableBase, IDatabaseContext, IConte
         {
             previous = Interlocked.Read(ref _maxNumberOfOpenConnections);
             if (current <= previous)
+            {
                 return; // no update needed
+            }
 
             // try to update only if no one else has changed it
         } while (Interlocked.CompareExchange(

--- a/pengdows.crud/EntityHelper.cs
+++ b/pengdows.crud/EntityHelper.cs
@@ -355,7 +355,10 @@ public class EntityHelper<TEntity, TRowID> :
     public ISqlContainer BuildCreate(TEntity objectToCreate, IDatabaseContext? context = null)
     {
         if (objectToCreate == null)
+        {
             throw new ArgumentNullException(nameof(objectToCreate));
+        }
+
         ValidateSameRoot(context);
         var ctx = context ?? _context;
         var columns = new StringBuilder();
@@ -588,7 +591,10 @@ public class EntityHelper<TEntity, TRowID> :
     public async Task<TEntity?> LoadSingleAsync(ISqlContainer sc)
     {
         await using var reader = await sc.ExecuteReaderAsync().ConfigureAwait(false);
-        if (await reader.ReadAsync().ConfigureAwait(false)) return MapReaderToObject(reader);
+        if (await reader.ReadAsync().ConfigureAwait(false))
+        {
+            return MapReaderToObject(reader);
+        }
 
         return null;
     }
@@ -1043,7 +1049,9 @@ public class EntityHelper<TEntity, TRowID> :
     {
         var idValue = _idColumn!.PropertyInfo.GetValue(objectToUpdate);
         if (IsDefaultId(idValue))
+        {
             return null;
+        }
 
         return await RetrieveOneAsync((TRowID)idValue!);
     }
@@ -1508,19 +1516,27 @@ public class EntityHelper<TEntity, TRowID> :
     private static bool IsDefaultId(object? value)
     {
         if (Utils.IsNullOrDbNull(value))
+        {
             return true;
+        }
 
         var type = typeof(TRowID);
         var underlying = Nullable.GetUnderlyingType(type) ?? type;
 
         if (underlying == typeof(string))
+        {
             return value as string == string.Empty;
+        }
 
         if (underlying == typeof(Guid))
+        {
             return value is Guid g && g == Guid.Empty;
+        }
 
         if (Utils.IsZeroNumeric(value!))
+        {
             return true;
+        }
 
         return EqualityComparer<TRowID>.Default.Equals((TRowID)value!, default!);
     }
@@ -1552,7 +1568,9 @@ public class EntityHelper<TEntity, TRowID> :
         }
 
         if (!isValid)
+        {
             throw new NotSupportedException(
                 $"TRowID type '{type.FullName}' is not supported. Use string, Guid, or integer types.");
+        }
     }
 }

--- a/pengdows.crud/EphemeralSecureString.cs
+++ b/pengdows.crud/EphemeralSecureString.cs
@@ -22,7 +22,10 @@ public sealed class EphemeralSecureString : IEphemeralSecureString, IDisposable
 
     public EphemeralSecureString(string input)
     {
-        if (input == null) throw new ArgumentNullException(nameof(input));
+        if (input == null)
+        {
+            throw new ArgumentNullException(nameof(input));
+        }
 
         _encoding = Encoding.UTF8;
 
@@ -37,11 +40,17 @@ public sealed class EphemeralSecureString : IEphemeralSecureString, IDisposable
 
     public string Reveal()
     {
-        if (Interlocked.Read(ref _disposed) == 1) throw new ObjectDisposedException(nameof(EphemeralSecureString));
+        if (Interlocked.Read(ref _disposed) == 1)
+        {
+            throw new ObjectDisposedException(nameof(EphemeralSecureString));
+        }
 
         lock (_lock)
         {
-            if (_cachedPlainBytes == null) _cachedPlainBytes = DecryptBytes(_cipherText, _key, _iv);
+            if (_cachedPlainBytes == null)
+            {
+                _cachedPlainBytes = DecryptBytes(_cipherText, _key, _iv);
+            }
 
             _timer?.Dispose();
             _timer = new Timer(ClearPlainText, null, TTL_MS, Timeout.Infinite);

--- a/pengdows.crud/ReflectionSerializer.cs
+++ b/pengdows.crud/ReflectionSerializer.cs
@@ -7,17 +7,33 @@ public static class ReflectionSerializer
 {
     private static bool IsSimpleType(Type type)
     {
-        if (type.IsEnum) return true;
+        if (type.IsEnum)
+        {
+            return true;
+        }
+
         var tc = Type.GetTypeCode(type);
         return tc != TypeCode.Object || type == typeof(Guid);
     }
 
     public static object? Serialize(object? obj)
     {
-        if (obj == null) return null;
+        if (obj == null)
+        {
+            return null;
+        }
+
         var type = obj.GetType();
-        if (IsSimpleType(type)) return obj;
-        if (obj is string) return obj;
+        if (IsSimpleType(type))
+        {
+            return obj;
+        }
+
+        if (obj is string)
+        {
+            return obj;
+        }
+
         if (obj is IDictionary dict)
         {
             var result = new Dictionary<string, object?>();
@@ -36,7 +52,11 @@ public static class ReflectionSerializer
         var objDict = new Dictionary<string, object?>();
         foreach (var prop in props)
         {
-            if (!prop.CanRead) continue;
+            if (!prop.CanRead)
+            {
+                continue;
+            }
+
             objDict[prop.Name] = Serialize(prop.GetValue(obj));
         }
         return objDict;
@@ -49,7 +69,11 @@ public static class ReflectionSerializer
 
     private static object? Deserialize(Type targetType, object? data)
     {
-        if (data == null) return null;
+        if (data == null)
+        {
+            return null;
+        }
+
         var underlying = Nullable.GetUnderlyingType(targetType);
         if (underlying != null)
         {
@@ -60,7 +84,11 @@ public static class ReflectionSerializer
         {
             return Convert.ChangeType(data, Nullable.GetUnderlyingType(targetType) ?? targetType);
         }
-        if (typeof(string) == targetType) return data.ToString();
+        if (typeof(string) == targetType)
+        {
+            return data.ToString();
+        }
+
         if (typeof(IDictionary).IsAssignableFrom(targetType) && data is IDictionary<string, object?> dictData)
         {
             var dict = (IDictionary)Activator.CreateInstance(targetType)!;
@@ -87,12 +115,18 @@ public static class ReflectionSerializer
         }
 
         if (data is not IDictionary<string, object?> objDict)
+        {
             throw new InvalidOperationException($"Cannot deserialize type {targetType}");
+        }
 
         var result = Activator.CreateInstance(targetType)!;
         foreach (var prop in targetType.GetProperties(BindingFlags.Instance | BindingFlags.Public))
         {
-            if (!prop.CanWrite) continue;
+            if (!prop.CanWrite)
+            {
+                continue;
+            }
+
             if (objDict.TryGetValue(prop.Name, out var val))
             {
                 var deserialized = Deserialize(prop.PropertyType, val);

--- a/pengdows.crud/SqlContainer.cs
+++ b/pengdows.crud/SqlContainer.cs
@@ -101,6 +101,36 @@ public class SqlContainer : SafeAsyncDisposableBase, ISqlContainer
         return parameter;
     }
 
+    public void SetParameterValue(string parameterName, object? newValue)
+    {
+        if (!_parameters.TryGetValue(parameterName, out var parameter))
+        {
+            throw new KeyNotFoundException($"Parameter '{parameterName}' not found.");
+        }
+
+        parameter.Value = newValue;
+    }
+
+    public object? GetParameterValue(string parameterName)
+    {
+        if (!_parameters.TryGetValue(parameterName, out var parameter))
+        {
+            throw new KeyNotFoundException($"Parameter '{parameterName}' not found.");
+        }
+
+        return parameter.Value;
+    }
+
+    public T GetParameterValue<T>(string parameterName)
+    {
+        var value = GetParameterValue(parameterName);
+        var sourceType = value?.GetType() ?? typeof(object);
+        var coerced = TypeCoercionHelper.Coerce(value, sourceType, typeof(T));
+
+        return (T)coerced!;
+    }
+
+
 
     public DbCommand CreateCommand(ITrackedConnection conn)
     {

--- a/pengdows.crud/SqlContainer.cs
+++ b/pengdows.crud/SqlContainer.cs
@@ -156,7 +156,9 @@ public class SqlContainer : SafeAsyncDisposableBase, ISqlContainer
         var procName = Query.ToString().Trim();
 
         if (string.IsNullOrWhiteSpace(procName))
+        {
             throw new InvalidOperationException("Procedure name is missing from the query.");
+        }
 
         var args = includeParameters ? BuildProcedureArguments() : string.Empty;
 
@@ -188,7 +190,9 @@ public class SqlContainer : SafeAsyncDisposableBase, ISqlContainer
         string BuildProcedureArguments()
         {
             if (_parameters.Count == 0)
+            {
                 return string.Empty;
+            }
 
             // Named parameter support check
             if (_context.SupportsNamedParameters)

--- a/pengdows.crud/TableInfo.cs
+++ b/pengdows.crud/TableInfo.cs
@@ -1,9 +1,14 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace pengdows.crud;
 
 public class TableInfo : ITableInfo
 {
+    private IReadOnlyList<IColumnInfo>? _orderedColumns;
+    private IReadOnlyList<IColumnInfo>? _primaryKeys;
+
     public Dictionary<string, IColumnInfo> Columns { get; } = new(StringComparer.OrdinalIgnoreCase);
     public string Schema { get; set; }
     public string Name { get; set; }
@@ -16,6 +21,20 @@ public class TableInfo : ITableInfo
     public IColumnInfo LastUpdatedOn { get; set; }
     public IColumnInfo CreatedOn { get; set; }
     public IColumnInfo CreatedBy { get; set; }
+
+    /// <summary>
+    /// Columns sorted by their ordinal.
+    /// </summary>
+    public IReadOnlyList<IColumnInfo> OrderedColumns =>
+        _orderedColumns ??= Columns.Values.OrderBy(c => c.Ordinal).ToList();
+
+    /// <summary>
+    /// Columns marked as primary keys, ordered by PkOrder.
+    /// </summary>
+    public IReadOnlyList<IColumnInfo> PrimaryKeys =>
+        _primaryKeys ??= Columns.Values.Where(c => c.IsPrimaryKey)
+            .OrderBy(k => k.PkOrder)
+            .ToList();
 
     /// <summary>
     /// Indicates whether this table contains any audit columns.

--- a/pengdows.crud/TypeCoercionHelper.cs
+++ b/pengdows.crud/TypeCoercionHelper.cs
@@ -25,17 +25,25 @@ public static class TypeCoercionHelper
         IColumnInfo columnInfo,
         EnumParseFailureMode parseMode = EnumParseFailureMode.Throw)
     {
-        if (Utils.IsNullOrDbNull(value)) return null;
+        if (Utils.IsNullOrDbNull(value))
+        {
+            return null;
+        }
 
         var targetType = columnInfo?.PropertyInfo?.PropertyType;
 
         if (dbFieldType == targetType)
+        {
             return value;
+        }
+
         // Enum coercion
         if (columnInfo?.EnumType != null)
         {
             if (Enum.TryParse(columnInfo.EnumType, value.ToString(), true, out var result))
+            {
                 return result;
+            }
 
             switch (parseMode)
             {
@@ -62,7 +70,10 @@ public static class TypeCoercionHelper
         if (columnInfo.IsJsonType)
         {
             if (value is string json && !string.IsNullOrWhiteSpace(json))
+            {
                 return JsonSerializer.Deserialize(json, targetType, columnInfo.JsonSerializerOptions);
+            }
+
             throw new ArgumentException($"Cannot deserialize JSON value '{value}' to type {targetType}.");
         }
 
@@ -74,10 +85,15 @@ public static class TypeCoercionHelper
         Type sourceType,
         Type targetType)
     {
-        if (Utils.IsNullOrDbNull(value)) return null;
+        if (Utils.IsNullOrDbNull(value))
+        {
+            return null;
+        }
 
         if (sourceType == targetType)
+        {
             return value;
+        }
 
         return CoerceCore(value, sourceType, targetType);
     }
@@ -88,13 +104,19 @@ public static class TypeCoercionHelper
         if (targetType == typeof(Guid))
         {
             if (value is string guidStr && Guid.TryParse(guidStr, out var guid))
+            {
                 return guid;
+            }
+
             if (value is byte[] bytes && bytes.Length == 16)
+            {
                 return new Guid(bytes);
+            }
         }
 
         // DateTime from string
         if (sourceType == typeof(string) && targetType == typeof(DateTime) && value is string s)
+        {
             try
             {
                 return DateTime.Parse(s, CultureInfo.InvariantCulture,
@@ -104,6 +126,7 @@ public static class TypeCoercionHelper
             {
                 throw new InvalidCastException($"Cannot convert value '{value}' to type '{targetType}'.", ex);
             }
+        }
 
         try
         {

--- a/pengdows.crud/Utils.cs
+++ b/pengdows.crud/Utils.cs
@@ -34,12 +34,26 @@ public class Utils
 
     public static bool IsNullOrEmpty<T>(IEnumerable<T>? collection)
     {
-        if (collection is null) return true;
+        if (collection is null)
+        {
+            return true;
+        }
 
         // If it's a known countable type, use .Count
-        if (collection is ICollection c) return c.Count == 0;
-        if (collection is ICollection<T> gc) return gc.Count == 0;
-        if (collection is IReadOnlyCollection<T> rc) return rc.Count == 0;
+        if (collection is ICollection c)
+        {
+            return c.Count == 0;
+        }
+
+        if (collection is ICollection<T> gc)
+        {
+            return gc.Count == 0;
+        }
+
+        if (collection is IReadOnlyCollection<T> rc)
+        {
+            return rc.Count == 0;
+        }
 
         // Otherwise enumerate once
         return !collection.Any();

--- a/pengdows.crud/configuration/DbProviderLoader.cs
+++ b/pengdows.crud/configuration/DbProviderLoader.cs
@@ -33,7 +33,9 @@ public class DbProviderLoader : IDbProviderLoader
             var providerKey = kvp.Key;
 
             if (string.IsNullOrEmpty(kvp.Value.ProviderName))
+            {
                 throw new InvalidOperationException($"ProviderName is missing for provider '{providerKey}'.");
+            }
 
             _logger.LogInformation("Loading DbProviderFactory for provider '{ProviderKey}'", providerKey);
 
@@ -79,6 +81,7 @@ public class DbProviderLoader : IDbProviderLoader
             lock (_lock)
             {
                 if (!_loadedAssemblies.TryGetValue(fullPath, out providerAssembly))
+                {
                     try
                     {
                         providerAssembly = Assembly.LoadFrom(fullPath);
@@ -95,6 +98,7 @@ public class DbProviderLoader : IDbProviderLoader
                             ex
                         );
                     }
+                }
             }
         }
         else if (!string.IsNullOrEmpty(config.AssemblyName))
@@ -102,6 +106,7 @@ public class DbProviderLoader : IDbProviderLoader
             lock (_lock)
             {
                 if (!_loadedAssemblies.TryGetValue(config.AssemblyName, out providerAssembly))
+                {
                     try
                     {
                         providerAssembly = Assembly.Load(config.AssemblyName);
@@ -118,6 +123,7 @@ public class DbProviderLoader : IDbProviderLoader
                             ex
                         );
                     }
+                }
             }
         }
 

--- a/pengdows.crud/isolation/IsolationLevelSupport.cs
+++ b/pengdows.crud/isolation/IsolationLevelSupport.cs
@@ -62,10 +62,14 @@ public class IsolationLevelSupport
     public void Validate(SupportedDatabase db, IsolationLevel level)
     {
         if (!SupportedIsolationLevels.TryGetValue(db, out var levels))
+        {
             throw new NotSupportedException($"Isolation level support not defined for database: {db}");
+        }
 
         if (!levels.Contains(level))
+        {
             throw new InvalidOperationException(
                 $"Isolation level {level} is not supported by {db}. Allowed: {string.Join(", ", levels)}");
+        }
     }
 }

--- a/pengdows.crud/isolation/IsolationResolver.cs
+++ b/pengdows.crud/isolation/IsolationResolver.cs
@@ -25,12 +25,16 @@ public sealed class IsolationResolver : IIsolationResolver
     public IsolationLevel Resolve(IsolationProfile profile)
     {
         if (!_profileMap.TryGetValue(profile, out var level))
+        {
             throw new NotSupportedException($"Profile {profile} not supported for {_product}");
+        }
 
         if (!_rcsi && _product == SupportedDatabase.PostgreSql &&
             profile == IsolationProfile.SafeNonBlockingReads && level == IsolationLevel.ReadCommitted)
+        {
             throw new InvalidOperationException(
                 $"Tenant {_product} does not have RCSI enabled. Profile {profile} maps to blocking isolation level.");
+        }
 
         Validate(level);
         return level;
@@ -39,7 +43,9 @@ public sealed class IsolationResolver : IIsolationResolver
     public void Validate(IsolationLevel level)
     {
         if (!_supportedLevels.Contains(level))
+        {
             throw new InvalidOperationException($"Isolation level {level} not supported by {_product} (RCSI: {_rcsi})");
+        }
     }
 
     public IReadOnlySet<IsolationLevel> GetSupportedLevels()

--- a/pengdows.crud/wrappers/TrackedConnection.cs
+++ b/pengdows.crud/wrappers/TrackedConnection.cs
@@ -54,7 +54,10 @@ public class TrackedConnection : ITrackedConnection, IAsyncDisposable
             _lockFactory = () => NoOpAsyncLocker.Instance;
         }
 
-        if (_onStateChange != null) _connection.StateChange += _onStateChange;
+        if (_onStateChange != null)
+        {
+            _connection.StateChange += _onStateChange;
+        }
     }
 
     public bool WasOpened => Interlocked.CompareExchange(ref _wasOpened, 0, 0) == 1;
@@ -79,7 +82,9 @@ public class TrackedConnection : ITrackedConnection, IAsyncDisposable
     public void Dispose()
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
             return;
+        }
 
         _logger.LogDebug("Disposing connection {Name}", _name);
 
@@ -115,7 +120,10 @@ public class TrackedConnection : ITrackedConnection, IAsyncDisposable
 
     private void TriggerFirstOpen()
     {
-        if (Interlocked.Exchange(ref _wasOpened, 1) == 0) _onFirstOpen?.Invoke(_connection);
+        if (Interlocked.Exchange(ref _wasOpened, 1) == 0)
+        {
+            _onFirstOpen?.Invoke(_connection);
+        }
     }
 
     public async Task OpenAsync(CancellationToken cancellationToken = default)
@@ -138,11 +146,16 @@ public class TrackedConnection : ITrackedConnection, IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
             return;
+        }
 
         _logger.LogDebug("Async disposing connection {Name}", _name);
 
-        if (_isSharedConnection && _semaphoreSlim != null) await _semaphoreSlim.WaitAsync().ConfigureAwait(false);
+        if (_isSharedConnection && _semaphoreSlim != null)
+        {
+            await _semaphoreSlim.WaitAsync().ConfigureAwait(false);
+        }
 
         try
         {
@@ -157,7 +170,10 @@ public class TrackedConnection : ITrackedConnection, IAsyncDisposable
         }
         finally
         {
-            if (_isSharedConnection && _semaphoreSlim != null) _semaphoreSlim.Release();
+            if (_isSharedConnection && _semaphoreSlim != null)
+            {
+                _semaphoreSlim.Release();
+            }
         }
     }
 

--- a/pengdows.crud/wrappers/TrackedReader.cs
+++ b/pengdows.crud/wrappers/TrackedReader.cs
@@ -31,7 +31,10 @@ public class TrackedReader : ITrackedReader
         if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 0)
         {
             _reader.Dispose();
-            if (_shouldCloseConnection) _connection.Close();
+            if (_shouldCloseConnection)
+            {
+                _connection.Close();
+            }
 
             _connectionLocker.DisposeAsync().AsTask().GetAwaiter().GetResult();
         }
@@ -39,7 +42,10 @@ public class TrackedReader : ITrackedReader
 
     public bool Read()
     {
-        if (_reader.Read()) return true;
+        if (_reader.Read())
+        {
+            return true;
+        }
 
         try
         {
@@ -178,7 +184,10 @@ public class TrackedReader : ITrackedReader
         if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 0)
         {
             await _reader.DisposeAsync();
-            if (_shouldCloseConnection) _connection.Close();
+            if (_shouldCloseConnection)
+            {
+                _connection.Close();
+            }
 
             await _connectionLocker.DisposeAsync();
         }
@@ -186,7 +195,10 @@ public class TrackedReader : ITrackedReader
 
     public async Task<bool> ReadAsync()
     {
-        if (await _reader.ReadAsync().ConfigureAwait(false)) return true;
+        if (await _reader.ReadAsync().ConfigureAwait(false))
+        {
+            return true;
+        }
 
         await DisposeAsync().ConfigureAwait(false); // Auto-dispose when done reading
         return false;

--- a/testbed/TestProvider.cs
+++ b/testbed/TestProvider.cs
@@ -1,6 +1,9 @@
 #region
 
+using Microsoft.Extensions.DependencyInjection;
+using System.Threading;
 using pengdows.crud;
+using pengdows.crud.enums;
 
 #endregion
 
@@ -8,13 +11,17 @@ namespace testbed;
 
 public class TestProvider : IAsyncTestProvider
 {
+    private static long _nextId;
+
     private readonly IDatabaseContext _context;
     private readonly EntityHelper<TestTable, long> _helper;
 
     public TestProvider(IDatabaseContext databaseContext, IServiceProvider serviceProvider)
     {
-        _context = databaseContext; //serviceProvider.GetService<IAuditValueResolver>()
-        _helper = new EntityHelper<TestTable, long>(databaseContext, auditValueResolver: new StubAuditValueResolver("system"));
+        _context = databaseContext;
+        var resolver = serviceProvider.GetService<IAuditValueResolver>() ??
+                       new StubAuditValueResolver("system");
+        _helper = new EntityHelper<TestTable, long>(databaseContext, auditValueResolver: resolver);
     }
 
 
@@ -27,13 +34,28 @@ public class TestProvider : IAsyncTestProvider
             await CreateTable();
 
             Console.WriteLine("Running Insert rows");
+            var before = await CountTestRows();
             var id = await InsertTestRows();
-            Console.WriteLine("Running test count");
-            await CountTestRows();
+            var afterInsert = await CountTestRows();
+            if (afterInsert != before + 1)
+            {
+                throw new Exception("Insert did not affect expected row count");
+            }
+
             Console.WriteLine("Running retrieve rows");
             var obj = await RetrieveRows(id);
+            if (obj.Id != id)
+            {
+                throw new Exception("Retrieved row did not match inserted id");
+            }
+
             Console.WriteLine("Running delete rows");
             await DeletedRow(obj);
+            var afterDelete = await CountTestRows();
+            if (afterDelete != before)
+            {
+                throw new Exception("Delete did not affect expected row count");
+            }
             Console.WriteLine("Running Transaction rows");
             await TestTransactions();
         }
@@ -70,17 +92,17 @@ public class TestProvider : IAsyncTestProvider
 
     private async Task TestCommitTransaction()
     {
-        var transaction = _context.BeginTransaction();
+        await using var transaction = _context.BeginTransaction();
         var id = await InsertTestRows(transaction);
-        var count = await CountTestRows(transaction);
+        await CountTestRows(transaction);
         transaction.Commit();
     }
 
     private async Task TestRollbackTransaction()
     {
-        var transaction = _context.BeginTransaction();
+        await using var transaction = _context.BeginTransaction();
         var id = await InsertTestRows(transaction);
-        var count = await CountTestRows(transaction);
+        await CountTestRows(transaction);
         transaction.Rollback();
     }
 
@@ -111,50 +133,39 @@ public class TestProvider : IAsyncTestProvider
         }
 
         sqlContainer.Query.Clear();
-        sqlContainer.Query.AppendFormat(@"
-CREATE TABLE {0}test_table{1} (
-    {0}id{1} BIGINT  NOT NULL UNIQUE, 
-    {0}name{1} VARCHAR(100) NOT NULL,
-    {0}description{1} VARCHAR(1000) NOT NULL,
-    {0}created_at{1} DATETIME NOT NULL,
-    {0}created_by{1} VARCHAR(100) NOT NULL,
-    {0}updated_at{1} DATETIME NOT NULL,
-    {0}updated_by{1} VARCHAR(100) NOT NULL
-    
-); ", qp, qs);
-        try
-        {
-            await sqlContainer.ExecuteNonQueryAsync();
-        }
-        catch (Exception e)
-        {
-            try
-            {
-                sqlContainer.Query.Clear();
-                sqlContainer.Query.AppendFormat("TRUNCATE TABLE {0}test_table{1}", qp, qs);
-                await sqlContainer.ExecuteNonQueryAsync();
-            }
-            catch
-            {
-                //eat error quitely if it doesn't support truncate table
-            }
-
-            Console.WriteLine(e.Message + "\n --- Continuing anyways");
-        }
+        var dateType = GetDateTimeType(databaseContext.Product);
+        sqlContainer.Query.Append($@"
+CREATE TABLE {qp}test_table{qs} (
+    {qp}id{qs} BIGINT NOT NULL,
+    {qp}name{qs} VARCHAR(100) NOT NULL,
+    {qp}description{qs} VARCHAR(1000) NOT NULL,
+    {qp}created_at{qs} {dateType} NOT NULL,
+    {qp}created_by{qs} VARCHAR(100) NOT NULL,
+    {qp}updated_at{qs} {dateType} NOT NULL,
+    {qp}updated_by{qs} VARCHAR(100) NOT NULL,
+    PRIMARY KEY ({qp}id{qs})
+);");
+        await sqlContainer.ExecuteNonQueryAsync();
     }
 
     private async Task<long> InsertTestRows(IDatabaseContext? db = null)
     {
         var ctx = db ?? _context;
         var name = ctx is TransactionContext ? NameEnum.Test2 : NameEnum.Test;
+        var id = Interlocked.Increment(ref _nextId);
         var t = new TestTable
         {
-            Id = Random.Shared.Next(),
+            Id = id,
             Name = name,
             Description = ctx.GenerateRandomName()
         };
         var sq = _helper.BuildCreate(t, ctx);
-        await sq.ExecuteNonQueryAsync();
+        var rows = await sq.ExecuteNonQueryAsync();
+        if (rows != 1)
+        {
+            throw new Exception("Insert failed");
+        }
+
         return t.Id;
     }
 
@@ -180,5 +191,14 @@ CREATE TABLE {0}test_table{1} (
         {
             throw new Exception("Delete failed");
         }
+    }
+
+    private static string GetDateTimeType(SupportedDatabase product)
+    {
+        return product switch
+        {
+            SupportedDatabase.PostgreSql => "TIMESTAMP WITH TIME ZONE",
+            _ => "DATETIME"
+        };
     }
 }

--- a/testbed/TestTable.cs
+++ b/testbed/TestTable.cs
@@ -10,31 +10,32 @@ namespace testbed;
 [Table("test_table")]
 public class TestTable
 {
-    [Id] [Column("id", DbType.Int64)] public long Id { get; set; }
+[Id]
+[Column("id", DbType.Int64)]
+public long Id { get; set; }
 
-    [PrimaryKey(1)]
     [Column("name", DbType.String)]
     [EnumColumn(typeof(NameEnum))]
-    public NameEnum? Name { get; set; }
+    public NameEnum Name { get; set; }
 
     [Column("description", DbType.String)]
-    public string? Description { get; set; }
+    public string Description { get; set; } = string.Empty;
 
     [CreatedOn]
     [Column("created_at", DbType.DateTime)]
-    public DateTime? CreatedAt { get; set; }
+    public DateTime CreatedAt { get; set; }
 
     [CreatedBy]
     [Column("created_by", DbType.String)]
-    public string? CreatedBy { get; set; }
+    public string CreatedBy { get; set; } = string.Empty;
 
     [LastUpdatedOn]
     [Column("updated_at", DbType.DateTime)]
-    public DateTime? UpdatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
 
     [LastUpdatedBy]
     [Column("updated_by", DbType.String)]
-    public string? UpdatedBy { get; set; }
+    public string UpdatedBy { get; set; } = string.Empty;
 }
 
 public enum NameEnum


### PR DESCRIPTION
## Summary
- align testbed POCO with non-nullable schema and introduce portable CREATE TABLE with primary key
- use scoped transactions and monotonic IDs in testbed provider while disposing containers consistently
- add tests validating table primary key mapping
- expose reusable query templates with deterministic parameter names and cache them for deletes, selects, and WHERE clauses
- use `TIMESTAMP WITH TIME ZONE` for PostgreSQL audit columns
- allow reading and updating parameter values within `SqlContainer`
- coerce parameter values with `TypeCoercionHelper` for cleaner `GetParameterValue` conversions
- cache WHERE parameter names and reuse existing parameters when rebuilding `IN` clauses
- expose raw parameter retrieval via `GetParameterValue` on `ISqlContainer`

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68ae008b50dc8325baceaae3c96a6ec3