### PR TITLE
feat: add mapper options and cached fast path

### DIFF
--- a/pengdows.crud.Tests/DataReaderMapperNegativeTests.cs
+++ b/pengdows.crud.Tests/DataReaderMapperNegativeTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using pengdows.crud.FakeDb;
@@ -26,6 +27,52 @@ public class DataReaderMapperNegativeTests
         Assert.Single(result);
         Assert.Equal("Alice", result[0].Name);
         Assert.Equal(0, result[0].Age); // default due to failed conversion
+    }
+
+    [Fact]
+    public async Task LoadAsync_WithStrict_ThrowsOnInvalidConversion()
+    {
+        var rows = new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["Name"] = "Alice",
+                ["Age"] = "NaN",
+                ["IsActive"] = true
+            }
+        };
+
+        var reader = new FakeDbDataReader(rows);
+        var options = new MapperOptions(Strict: true);
+        IDataReaderMapper mapper = new DataReaderMapper();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            mapper.LoadAsync<SampleEntity>(reader, options));
+    }
+
+    [Fact]
+    public async Task StreamAsync_WithStrict_ThrowsOnInvalidConversion()
+    {
+        var rows = new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["Name"] = "Alice",
+                ["Age"] = "NaN",
+                ["IsActive"] = true
+            }
+        };
+
+        var reader = new FakeDbDataReader(rows);
+        var options = new MapperOptions(Strict: true);
+        var stream = DataReaderMapper.StreamAsync<SampleEntity>(reader, options);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var _ in stream)
+            {
+            }
+        });
     }
 
     private class SampleEntity

--- a/pengdows.crud.Tests/DataReaderMapperTests.cs
+++ b/pengdows.crud.Tests/DataReaderMapperTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Threading.Tasks;
 using pengdows.crud.FakeDb;
+using pengdows.crud.attributes;
 using Xunit;
 
 #endregion
@@ -53,6 +54,28 @@ public class DataReaderMapperTests
     }
 
     [Fact]
+    public async Task LoadObjectsFromDataReaderAsync_Interface_MapsFields()
+    {
+        var reader = new FakeDbDataReader(new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["Name"] = "John",
+                ["Age"] = 30,
+                ["IsActive"] = true
+            }
+        });
+
+        IDataReaderMapper mapper = new DataReaderMapper();
+        var result = await mapper.LoadObjectsFromDataReaderAsync<SampleEntity>(reader);
+
+        Assert.Single(result);
+        Assert.Equal("John", result[0].Name);
+        Assert.Equal(30, result[0].Age);
+        Assert.True(result[0].IsActive);
+    }
+
+    [Fact]
     public async Task LoadObjectsFromDataReaderAsync_HandlesDbNullsGracefully()
     {
         var reader = new FakeDbDataReader(new[]
@@ -72,12 +95,127 @@ public class DataReaderMapperTests
         Assert.Equal(0, result[0].Age); // default(int)
         Assert.False(result[0].IsActive); // default(bool)
     }
-  [Fact]
+
+    [Fact]
+    public async Task StreamAsync_StreamsObjects()
+    {
+        var reader = new FakeDbDataReader(new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["Name"] = "John",
+                ["Age"] = 30,
+                ["IsActive"] = true
+            },
+            new Dictionary<string, object>
+            {
+                ["Name"] = "Jane",
+                ["Age"] = 25,
+                ["IsActive"] = false
+            }
+        });
+
+        var results = new List<SampleEntity>();
+        await foreach (var item in DataReaderMapper.StreamAsync<SampleEntity>(reader))
+        {
+            results.Add(item);
+        }
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal("John", results[0].Name);
+        Assert.Equal("Jane", results[1].Name);
+    }
+    [Fact]
     public async Task LoadObjectsFromDataReaderAsync_ThrowsForNonDbDataReader()
     {
         var reader = new NonDbDataReader();
         await Assert.ThrowsAsync<ArgumentException>(async () =>
             await DataReaderMapper.LoadObjectsFromDataReaderAsync<SampleEntity>(reader));
+    }
+
+    [Fact]
+    public async Task LoadAsync_WithNamePolicy_MapsSnakeCaseFields()
+    {
+        var reader = new FakeDbDataReader(new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["first_name"] = "John"
+            }
+        });
+
+        Func<string, string> snakeToPascal = name =>
+        {
+            var parts = name.Split('_', StringSplitOptions.RemoveEmptyEntries);
+            var result = string.Empty;
+            foreach (var part in parts)
+            {
+                result += char.ToUpperInvariant(part[0]) + part.Substring(1);
+            }
+
+            return result;
+        };
+
+        var options = new MapperOptions(NamePolicy: snakeToPascal);
+        var result = await DataReaderMapper.LoadAsync<SnakeEntity>(reader, options);
+
+        Assert.Single(result);
+        Assert.Equal("John", result[0].FirstName);
+    }
+
+    [Fact]
+    public async Task LoadObjectsFromDataReaderAsync_WithoutNamePolicy_IgnoresSnakeCaseFields()
+    {
+        var reader = new FakeDbDataReader(new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["first_name"] = "John"
+            }
+        });
+
+        var result = await DataReaderMapper.LoadObjectsFromDataReaderAsync<SnakeEntity>(reader);
+
+        Assert.Single(result);
+        Assert.Null(result[0].FirstName);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ColumnsOnly_MapsAnnotatedProperty()
+    {
+        var reader = new FakeDbDataReader(new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["Name"] = "Jane",
+                ["Age"] = 25
+            }
+        });
+
+        var options = new MapperOptions(ColumnsOnly: true);
+        var result = await DataReaderMapper.LoadAsync<ColumnsOnlyEntity>(reader, options);
+
+        Assert.Single(result);
+        Assert.Equal("Jane", result[0].Name);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ColumnsOnly_IgnoresNonAnnotatedProperty()
+    {
+        var reader = new FakeDbDataReader(new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["Name"] = "Jane",
+                ["Age"] = 25
+            }
+        });
+
+        var options = new MapperOptions(ColumnsOnly: true);
+        var result = await DataReaderMapper.LoadAsync<ColumnsOnlyEntity>(reader, options);
+
+        Assert.Single(result);
+        Assert.Equal(0, result[0].Age);
     }
 
     private class NonDbDataReader : IDataReader
@@ -125,5 +263,18 @@ public class DataReaderMapperTests
         public string Name { get; set; }
         public int Age { get; set; }
         public bool IsActive { get; set; }
+    }
+
+    private class SnakeEntity
+    {
+        public string? FirstName { get; set; }
+    }
+
+    private class ColumnsOnlyEntity
+    {
+        [Column("Name", DbType.String)]
+        public string? Name { get; set; }
+
+        public int Age { get; set; }
     }
 }

--- a/pengdows.crud.abstractions/IDataReaderMapper.cs
+++ b/pengdows.crud.abstractions/IDataReaderMapper.cs
@@ -1,0 +1,49 @@
+#region
+
+using System.Collections.Generic;
+using System.Data;
+using System.Threading;
+using System.Threading.Tasks;
+
+#endregion
+
+namespace pengdows.crud;
+
+/// <summary>
+/// Maps data reader rows to objects using optional mapping options.
+/// </summary>
+public interface IDataReaderMapper
+{
+    /// <summary>
+    /// Hydrates a list of objects from an <see cref="IDataReader"/> using default options.
+    /// </summary>
+    /// <typeparam name="T">Type of object to hydrate.</typeparam>
+    /// <param name="reader">Data reader containing the rows to map.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of hydrated objects.</returns>
+    Task<List<T>> LoadObjectsFromDataReaderAsync<T>(IDataReader reader, CancellationToken cancellationToken = default)
+        where T : class, new();
+
+    /// <summary>
+    /// Hydrates a list of objects from an <see cref="IDataReader"/> using the provided <see cref="MapperOptions"/>.
+    /// </summary>
+    /// <typeparam name="T">Type of object to hydrate.</typeparam>
+    /// <param name="reader">Data reader containing the rows to map.</param>
+    /// <param name="options">Mapping options controlling hydration behavior.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of hydrated objects.</returns>
+    Task<List<T>> LoadAsync<T>(IDataReader reader, MapperOptions options, CancellationToken cancellationToken = default)
+        where T : class, new();
+
+    /// <summary>
+    /// Streams objects from an <see cref="IDataReader"/> using the provided <see cref="MapperOptions"/>.
+    /// </summary>
+    /// <typeparam name="T">Type of object to hydrate.</typeparam>
+    /// <param name="reader">Data reader containing the rows to map.</param>
+    /// <param name="options">Mapping options controlling hydration behavior.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Async sequence of hydrated objects.</returns>
+    IAsyncEnumerable<T> StreamAsync<T>(IDataReader reader, MapperOptions options, CancellationToken cancellationToken = default)
+        where T : class, new();
+}
+

--- a/pengdows.crud.abstractions/MapperOptions.cs
+++ b/pengdows.crud.abstractions/MapperOptions.cs
@@ -1,0 +1,18 @@
+#region
+
+using System;
+using pengdows.crud.enums;
+
+#endregion
+
+namespace pengdows.crud;
+
+public sealed record MapperOptions(
+    bool Strict = false,
+    bool ColumnsOnly = false,
+    Func<string, string>? NamePolicy = null,
+    EnumParseFailureMode EnumMode = EnumParseFailureMode.Throw)
+{
+    public static readonly MapperOptions Default = new();
+}
+


### PR DESCRIPTION
## Summary
- add MapperOptions to control strictness, column enforcement, and naming policy
- cache mapper plans with compiled setters for faster hydration
- expose async streaming API returning `IAsyncEnumerable<T>`
- cover name policy, column-only, streaming, and strict modes with tests
- expose DataReaderMapper via IDataReaderMapper for DI-friendly usage

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b07a5cd6408325b5b6b307e2c6f4b6