### PR TITLE
fix: improve SQL standard level detection

### DIFF
--- a/pengdows.crud.Tests/SqlStandardLevelTests.cs
+++ b/pengdows.crud.Tests/SqlStandardLevelTests.cs
@@ -54,4 +54,28 @@ public class SqlStandardLevelTests
         var info = DataSourceInformation.Create(tracked, factory);
         Assert.Equal(SqlStandardLevel.Sql2003, info.StandardCompliance);
     }
+
+    [Fact]
+    public void StandardCompliance_VeryOldSqlServer_UsesDefault()
+    {
+        var schema = DataSourceInformation.BuildEmptySchema(
+            "Microsoft SQL Server",
+            "7.0",
+            "@[0-9]+",
+            "@{0}",
+            64,
+            @"@\w+",
+            @"@\w+",
+            true);
+        var scalars = new Dictionary<string, object>
+        {
+            ["SELECT @@VERSION"] = "Microsoft SQL Server 7.0"
+        };
+        var factory = new fakeDbFactory(SupportedDatabase.SqlServer);
+        var conn = (fakeDbConnection)factory.CreateConnection();
+        conn.ConnectionString = $"Data Source=test;EmulatedProduct={SupportedDatabase.SqlServer}";
+        var tracked = new FakeTrackedConnection(conn, schema, scalars);
+        var info = DataSourceInformation.Create(tracked, factory);
+        Assert.Equal(SqlStandardLevel.Sql2008, info.StandardCompliance);
+    }
 }

--- a/pengdows.crud/dialects/PostgreSqlDialect.cs
+++ b/pengdows.crud/dialects/PostgreSqlDialect.cs
@@ -114,7 +114,8 @@ SET search_path = public;";
             { 15, SqlStandardLevel.Sql2016 },
             { 13, SqlStandardLevel.Sql2011 },
             { 11, SqlStandardLevel.Sql2008 },
-            { 9, SqlStandardLevel.Sql2003 }
+            { 9, SqlStandardLevel.Sql2003 },
+            { 8, SqlStandardLevel.Sql92 }
         };
     }
 

--- a/pengdows.crud/dialects/SqlServerDialect.cs
+++ b/pengdows.crud/dialects/SqlServerDialect.cs
@@ -178,7 +178,8 @@ public class SqlServerDialect : SqlDialect
         {
             { 13, SqlStandardLevel.Sql2016 }, // SQL Server 2016+
             { 12, SqlStandardLevel.Sql2011 }, // SQL Server 2014
-            { 10, SqlStandardLevel.Sql2008 }  // SQL Server 2008+
+            { 10, SqlStandardLevel.Sql2008 }, // SQL Server 2008+
+            { 8,  SqlStandardLevel.Sql2003 }  // SQL Server 2000+
         };
     }
 


### PR DESCRIPTION
## Summary
- handle missing version mappings when determining SQL standard level
- treat versions without build numbers as zero when comparing
- expand SQL Server and PostgreSQL version maps
- cover very old SQL Server versions in tests

## Testing
- `dotnet test -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68b9bce303388325b9cfe0f74d903d16