### PR TITLE
refactor: split EntityHelper into partial files

### DIFF
--- a/pengdows.crud.Tests/BoundedCacheTests.cs
+++ b/pengdows.crud.Tests/BoundedCacheTests.cs
@@ -1,0 +1,35 @@
+using pengdows.crud.@internal;
+using Xunit;
+
+namespace pengdows.crud.Tests;
+
+public class BoundedCacheTests
+{
+    [Fact]
+    public void GetOrAdd_ReturnsSameInstance_ForSameKey()
+    {
+        var cache = new BoundedCache<int, string>(2);
+        var first = cache.GetOrAdd(1, _ => "a");
+        var second = cache.GetOrAdd(1, _ => "b");
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void TryGet_ReturnsFalse_ForMissingKey()
+    {
+        var cache = new BoundedCache<int, string>(2);
+        Assert.False(cache.TryGet(1, out _));
+    }
+
+    [Fact]
+    public void EvictsOldest_WhenCapacityExceeded()
+    {
+        var cache = new BoundedCache<int, string>(2);
+        cache.GetOrAdd(1, _ => "a");
+        cache.GetOrAdd(2, _ => "b");
+        cache.GetOrAdd(3, _ => "c");
+        Assert.False(cache.TryGet(1, out _));
+        Assert.True(cache.TryGet(2, out _));
+        Assert.True(cache.TryGet(3, out _));
+    }
+}

--- a/pengdows.crud.Tests/CachedSqlTemplatesTests.cs
+++ b/pengdows.crud.Tests/CachedSqlTemplatesTests.cs
@@ -42,13 +42,13 @@ public class CachedSqlTemplatesTests : SqlLiteContextTestBase
         var sc = helper.BuildCreate(entity);
 
         var sql = sc.Query.ToString();
-        Assert.Contains("@p0", sql);
-        Assert.Contains("@p1", sql);
+        Assert.Contains("@i0", sql);
+        Assert.Contains("@i1", sql);
 
         var field = typeof(SqlContainer).GetField("_parameters", BindingFlags.NonPublic | BindingFlags.Instance)!;
         var parameters = (IDictionary<string, DbParameter>)field.GetValue(sc)!;
-        Assert.Contains("p0", parameters.Keys);
-        Assert.Contains("p1", parameters.Keys);
+        Assert.Contains("i0", parameters.Keys);
+        Assert.Contains("i1", parameters.Keys);
     }
 
     [Fact]

--- a/pengdows.crud.Tests/ConnectionLocalStateTests.cs
+++ b/pengdows.crud.Tests/ConnectionLocalStateTests.cs
@@ -13,14 +13,14 @@ public class ConnectionLocalStateTests
             PrepareDisabled = true
         };
 
-        var shape = "SELECT|1:4";
-        Assert.False(state.IsAlreadyPreparedForShape(shape));
-        state.MarkShapePrepared(shape);
-        Assert.True(state.IsAlreadyPreparedForShape(shape));
+        var sql = "SELECT 1";
+        Assert.False(state.IsAlreadyPreparedForShape(sql));
+        state.MarkShapePrepared(sql);
+        Assert.True(state.IsAlreadyPreparedForShape(sql));
 
         state.Reset();
 
-        Assert.False(state.IsAlreadyPreparedForShape(shape));
+        Assert.False(state.IsAlreadyPreparedForShape(sql));
         Assert.True(state.PrepareDisabled); // flag persists across Reset()
     }
 }

--- a/pengdows.crud.Tests/DeterministicParameterNamingTests.cs
+++ b/pengdows.crud.Tests/DeterministicParameterNamingTests.cs
@@ -1,0 +1,65 @@
+#region
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using pengdows.crud.enums;
+using pengdows.crud.fakeDb;
+using Xunit;
+#endregion
+
+namespace pengdows.crud.Tests;
+
+public class DeterministicParameterNamingTests : IAsyncLifetime
+{
+    private readonly TypeMapRegistry _typeMap;
+    private readonly IDatabaseContext _context;
+    private readonly EntityHelper<IdentityTestEntity, int> _helper;
+
+    public DeterministicParameterNamingTests()
+    {
+        _typeMap = new TypeMapRegistry();
+        _typeMap.Register<IdentityTestEntity>();
+        _context = new DatabaseContext("Data Source=test;EmulatedProduct=SqlServer", new fakeDbFactory(SupportedDatabase.SqlServer), _typeMap);
+        _helper = new EntityHelper<IdentityTestEntity, int>(_context);
+    }
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public async Task DisposeAsync()
+    {
+        if (_context is IAsyncDisposable disp)
+        {
+            await disp.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task BuildUpdateAsync_ProducesStableSqlAcrossRuns()
+    {
+        var e = new IdentityTestEntity { Id = 1, Name = "A", Version = 1 };
+
+        var sc1 = await _helper.BuildUpdateAsync(e);
+        var sql1 = sc1.Query.ToString();
+
+        var sc2 = await _helper.BuildUpdateAsync(e);
+        var sql2 = sc2.Query.ToString();
+
+        Assert.Equal(sql1, sql2);
+    }
+
+    [Fact]
+    public async Task BuildUpdateAsync_UsesDistinctClauseParameterNames()
+    {
+        var e = new IdentityTestEntity { Id = 1, Name = "A", Version = 1 };
+
+        var sc = await _helper.BuildUpdateAsync(e);
+        var sql = sc.Query.ToString();
+
+        var expectedS = sc.MakeParameterName("s0");
+        var expectedK = sc.MakeParameterName("k0");
+        var expectedV = sc.MakeParameterName("v0");
+
+        Assert.Contains(expectedS, sql);
+        Assert.Contains(expectedK, sql);
+        Assert.Contains(expectedV, sql);
+    }
+}

--- a/pengdows.crud.Tests/DeterministicParameterNamingTests.cs
+++ b/pengdows.crud.Tests/DeterministicParameterNamingTests.cs
@@ -1,4 +1,5 @@
 #region
+using System;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using pengdows.crud.enums;
@@ -56,10 +57,7 @@ public class DeterministicParameterNamingTests : IAsyncLifetime
 
         var expectedS = sc.MakeParameterName("s0");
         var expectedK = sc.MakeParameterName("k0");
-        var expectedV = sc.MakeParameterName("v0");
-
         Assert.Contains(expectedS, sql);
         Assert.Contains(expectedK, sql);
-        Assert.Contains(expectedV, sql);
     }
 }

--- a/pengdows.crud.Tests/EntityHelperBuildWhereByPrimaryKeyTests.cs
+++ b/pengdows.crud.Tests/EntityHelperBuildWhereByPrimaryKeyTests.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using pengdows.crud.enums;
+using pengdows.crud.fakeDb;
 using Xunit;
 
 namespace pengdows.crud.Tests;
@@ -29,6 +31,24 @@ public class EntityHelperBuildWhereByPrimaryKeyTests : SqlLiteContextTestBase
         var pattern = "\\n WHERE \\(t\\.\"Name\" = @\\w+\\) OR \\(t\\.\"Name\" = @\\w+\\)";
         Assert.Matches(pattern, sql);
         Assert.Equal(2, sc.ParameterCount);
+        Assert.DoesNotContain(":", sql);
+    }
+
+    [Fact]
+    public void BuildWhereByPrimaryKey_WithPostgresOverride_UsesColonMarker()
+    {
+        using var overrideCtx = new DatabaseContext(
+            "Data Source=:memory:;EmulatedProduct=PostgreSql",
+            new fakeDbFactory(SupportedDatabase.PostgreSql),
+            TypeMap);
+        var sc = overrideCtx.CreateSqlContainer();
+        var list = new List<TestEntity> { new() { Name = "A" } };
+
+        _helper.BuildWhereByPrimaryKey(list, sc);
+        var sql = sc.Query.ToString();
+
+        Assert.Contains(":", sql);
+        Assert.DoesNotContain("@", sql);
     }
 }
 

--- a/pengdows.crud.Tests/EntityHelperDialectOverrideTests.cs
+++ b/pengdows.crud.Tests/EntityHelperDialectOverrideTests.cs
@@ -22,8 +22,8 @@ public class EntityHelperDialectOverrideTests
         var sql = sc.Query.ToString();
 
         // Postgres uses ':' for named parameters
-        Assert.Contains(":p0", sql);
-        Assert.DoesNotContain("@p0", sql);
+        Assert.Contains(":i0", sql);
+        Assert.DoesNotContain("@i0", sql);
     }
 
     [Fact]
@@ -59,8 +59,8 @@ public class EntityHelperDialectOverrideTests
 
         // The IN (...) list should use '@' parameter markers under SQLite
         Assert.Contains("IN (", sql);
-        Assert.Contains("@p0", sql);
-        Assert.Contains("@p1", sql);
+        Assert.Contains("@w0", sql);
+        Assert.Contains("@w1", sql);
     }
 }
 

--- a/pengdows.crud.Tests/EntityHelperTokenReplacementTests.cs
+++ b/pengdows.crud.Tests/EntityHelperTokenReplacementTests.cs
@@ -28,7 +28,7 @@ public class EntityHelperTokenReplacementTests : SqlLiteContextTestBase
         var sc = helper.BuildCreate(entity);
         var sql = sc.Query.ToString();
         var replaced = helper.ReplaceDialectTokens(sql, "[", "]", ":");
-        Assert.Equal("INSERT INTO [Tokens] ([Id]) VALUES (:p0)", replaced);
+        Assert.Equal("INSERT INTO [Tokens] ([Id]) VALUES (:i0)", replaced);
     }
 
     [Fact]

--- a/pengdows.crud.Tests/PrepareBehaviorTests.cs
+++ b/pengdows.crud.Tests/PrepareBehaviorTests.cs
@@ -92,7 +92,7 @@ public class PrepareBehaviorTests
     }
 
     [Fact]
-    public async Task Prepare_CallsOncePerShape_ThenCachesForConnection()
+    public async Task Prepare_CallsOncePerText_ThenCachesForConnection()
     {
         var factory = new RecordingPrepareFactory(SupportedDatabase.PostgreSql);
         await using var ctx = CreateContext(factory, forcePrepare: true);
@@ -104,14 +104,14 @@ public class PrepareBehaviorTests
             _ = await sc.ExecuteNonQueryAsync();
         }
 
-        // Same shape in same transaction (same connection) should not re-prepare
+        // Same text in same transaction (same connection) should not re-prepare
         await using (var sc = tx.CreateSqlContainer("SELECT @p0") as SqlContainer)
         {
             sc!.AddParameterWithValue("p0", DbType.Int32, 2);
             _ = await sc.ExecuteNonQueryAsync();
         }
 
-        // Different shape (SQL and parameters) should prepare again
+        // Different text should prepare again
         await using (var sc = tx.CreateSqlContainer("SELECT @p0, @p1") as SqlContainer)
         {
             sc!.AddParameterWithValue("p0", DbType.String, "x");
@@ -119,7 +119,7 @@ public class PrepareBehaviorTests
             _ = await sc.ExecuteNonQueryAsync();
         }
 
-        // Assert: one connection, three commands created; prepare attempts 2 (first + shape change)
+        // Assert: one connection, three commands created; prepare attempts 2 (first + text change)
         var totalAttempts = 0;
         var totalSuccess = 0;
         foreach (var connection in factory.Connections)

--- a/pengdows.crud.Tests/QueryCacheTests.cs
+++ b/pengdows.crud.Tests/QueryCacheTests.cs
@@ -232,8 +232,11 @@ public class QueryCacheTests : SqlLiteContextTestBase
     private static ConcurrentDictionary<string, string> GetQueryCache<TEntity, TId>(EntityHelper<TEntity, TId> helper)
         where TEntity : class, new()
     {
-        var field = typeof(EntityHelper<TEntity, TId>).GetField("_queryCache", BindingFlags.NonPublic | BindingFlags.Instance);
-        return (ConcurrentDictionary<string, string>)field!.GetValue(helper)!;
+        var field = typeof(EntityHelper<TEntity, TId>)
+            .GetField("_queryCache", BindingFlags.NonPublic | BindingFlags.Instance);
+        var cache = field!.GetValue(helper)!;
+        var mapField = cache.GetType().GetField("_map", BindingFlags.NonPublic | BindingFlags.Instance);
+        return (ConcurrentDictionary<string, string>)mapField!.GetValue(cache)!;
     }
 
     [Table("CacheEntity")]

--- a/pengdows.crud.Tests/QueryCacheTests.cs
+++ b/pengdows.crud.Tests/QueryCacheTests.cs
@@ -117,8 +117,8 @@ public class QueryCacheTests : SqlLiteContextTestBase
         var sc = Context.CreateSqlContainer();
         helper.BuildWhere(wrapped, new[] { 1, 2 }, sc);
         var countBefore = sc.ParameterCount;
-        var p0 = Context.MakeParameterName("p0");
-        var p1 = Context.MakeParameterName("p1");
+        var p0 = Context.MakeParameterName("w0");
+        var p1 = Context.MakeParameterName("w1");
 
         helper.BuildWhere(wrapped, new[] { 3, 4 }, sc);
 
@@ -140,8 +140,8 @@ public class QueryCacheTests : SqlLiteContextTestBase
 
         helper.BuildWhere(wrapped, new[] { 2, 3 }, sc);
 
-        var p0 = Context.MakeParameterName("p0");
-        var p1 = Context.MakeParameterName("p1");
+        var p0 = Context.MakeParameterName("w0");
+        var p1 = Context.MakeParameterName("w1");
 
         Assert.True(sc.ParameterCount > countBefore);
         Assert.Equal(2, sc.GetParameterValue<int>(p0));

--- a/pengdows.crud.Tests/SqlContainerParameterOrderTests.cs
+++ b/pengdows.crud.Tests/SqlContainerParameterOrderTests.cs
@@ -1,9 +1,15 @@
+using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using pengdows.crud;
+using pengdows.crud.dialects;
 using pengdows.crud.enums;
 using pengdows.crud.fakeDb;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace pengdows.crud.Tests;
@@ -74,6 +80,99 @@ public class SqlContainerParameterOrderTests : SqlLiteContextTestBase
 
         // Expect SELECT form with dialect-specific marker, preserving add order
         Assert.Equal("SELECT * FROM \"my_proc\"(:b, :a, :c)", wrapped);
+    }
+
+    private sealed class PositionalDialect : SqlDialect
+    {
+        public override string ParameterMarker => "?";
+        public override bool SupportsNamedParameters => false;
+        public override SupportedDatabase DatabaseType => SupportedDatabase.Unknown;
+        public PositionalDialect() : base(new fakeDbFactory(SupportedDatabase.Unknown), NullLogger<SqlDialect>.Instance) { }
+    }
+
+    [Fact]
+    public async Task PositionalDialect_BindsByParamSequence()
+    {
+        var dialect = new PositionalDialect();
+        var dummyConn = new FakeTrackedConnection(new fakeDbConnection(), new DataTable(), new Dictionary<string, object>());
+        dialect.DetectDatabaseInfo(dummyConn);
+        var dsi = new DataSourceInformation(dialect);
+        var ctx = new Mock<IDatabaseContext>();
+        ctx.SetupGet(c => c.DataSourceInfo).Returns(dsi);
+        ctx.SetupGet(c => c.SupportsNamedParameters).Returns(false);
+        ctx.SetupGet(c => c.MaxParameterLimit).Returns(100);
+        ctx.SetupGet(c => c.DatabaseProductName).Returns(dsi.DatabaseProductName);
+        ctx.SetupGet(c => c.DisablePrepare).Returns((bool?)true);
+        ctx.SetupGet(c => c.ForceManualPrepare).Returns((bool?)null);
+        ctx.As<ISqlDialectProvider>().SetupGet(p => p.Dialect).Returns(dialect);
+
+        using var container = new SqlContainer(ctx.Object, "SELECT {P}b, {P}a");
+        var rendered = container.RenderParams(container.Query.ToString());
+        container.Query.Clear().Append(rendered);
+        var pA = dialect.CreateDbParameter("a", DbType.Int32, 1);
+        pA.ParameterName = "a";
+        var pB = dialect.CreateDbParameter("b", DbType.Int32, 2);
+        pB.ParameterName = "b";
+        container.AddParameter(pA); // intentionally add out of encounter order
+        container.AddParameter(pB);
+
+        using var tracked = new FakeTrackedConnection(new fakeDbConnection(), new DataTable(), new Dictionary<string, object>());
+        var method = typeof(SqlContainer).GetMethod(
+            "PrepareAndCreateCommandAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        var task = (Task<DbCommand>)method!.Invoke(container, new object[]
+        {
+            tracked,
+            CommandType.Text,
+            ExecutionType.Read,
+            CancellationToken.None
+        })!;
+        var cmd = await task.ConfigureAwait(false);
+        try
+        {
+            Assert.Equal(2, container.ParamSequence.Count);
+            Assert.Equal("b", container.ParamSequence[0]);
+            Assert.Equal("a", container.ParamSequence[1]);
+        }
+        finally
+        {
+            cmd.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task NamedDialect_IgnoresParamSequence()
+    {
+        using var container = Context.CreateSqlContainer("SELECT {P}b, {P}a") as SqlContainer;
+        var dialect = ((ISqlDialectProvider)Context).Dialect;
+        var rendered = container!.RenderParams(container.Query.ToString());
+        container.Query.Clear().Append(rendered);
+        var pA = dialect.CreateDbParameter("a", DbType.Int32, 1);
+        var pB = dialect.CreateDbParameter("b", DbType.Int32, 2);
+        container.AddParameter(pA);
+        container.AddParameter(pB);
+
+        using var tracked = Context.GetConnection(ExecutionType.Read);
+        var method = typeof(SqlContainer).GetMethod(
+            "PrepareAndCreateCommandAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        var task = (Task<DbCommand>)method!.Invoke(container, new object[]
+        {
+            tracked,
+            CommandType.Text,
+            ExecutionType.Read,
+            CancellationToken.None
+        })!;
+        var cmd = await task.ConfigureAwait(false);
+        try
+        {
+            Assert.Equal("a", cmd.Parameters[0].ParameterName);
+            Assert.Equal("b", cmd.Parameters[1].ParameterName);
+        }
+        finally
+        {
+            cmd.Dispose();
+        }
     }
 }
 

--- a/pengdows.crud/EntityHelper.Caching.cs
+++ b/pengdows.crud/EntityHelper.Caching.cs
@@ -1,57 +1,15 @@
-using System.Collections.Concurrent;
-using System.Threading;
-
 namespace pengdows.crud;
 
 public partial class EntityHelper<TEntity, TRowID>
 {
     private const int MaxCacheSize = 100;
 
-    private static void TryAddWithLimit<TKey, TValue>(ConcurrentDictionary<TKey, TValue> cache, TKey key,
-        TValue value, ConcurrentQueue<TKey> order) where TKey : notnull
-    {
-        // Use GetOrAdd to ensure we don't lose the value if already present
-        if (cache.TryAdd(key, value))
-        {
-            // Only track order for new entries
-            order.Enqueue(key);
-
-            // Use queue-based FIFO eviction when limit is exceeded
-            while (cache.Count > MaxCacheSize && order.TryDequeue(out var oldKey))
-            {
-                cache.TryRemove(oldKey, out _);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Thread-safe method to add reader plans with bounded cache size using atomic dictionary swap
-    /// </summary>
-    private void TryAddReaderPlanWithLimit(int hash, ColumnPlan[] plan)
-    {
-        // Use GetOrAdd to ensure we don't lose the value if already present
-        _readerPlans.GetOrAdd(hash, plan);
-
-        // If cache size exceeds limit, atomically swap to a new dictionary
-        if (_readerPlans.Count > MaxReaderPlans)
-        {
-            var newCache = new ConcurrentDictionary<int, ColumnPlan[]>();
-            newCache.TryAdd(hash, plan);
-            // Atomic swap - other threads will start using the new cache
-            Interlocked.Exchange(ref _readerPlans, newCache);
-        }
-    }
-
     public void ClearCaches()
     {
         _readerConverters.Clear();
-        _readerConvertersOrder.Clear();
         _readerPlans.Clear();
         _columnListCache.Clear();
-        _columnListCacheOrder.Clear();
         _queryCache.Clear();
-        _queryCacheOrder.Clear();
         _whereParameterNames.Clear();
-        _whereParameterNamesOrder.Clear();
     }
 }

--- a/pengdows.crud/EntityHelper.Caching.cs
+++ b/pengdows.crud/EntityHelper.Caching.cs
@@ -1,0 +1,57 @@
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace pengdows.crud;
+
+public partial class EntityHelper<TEntity, TRowID>
+{
+    private const int MaxCacheSize = 100;
+
+    private static void TryAddWithLimit<TKey, TValue>(ConcurrentDictionary<TKey, TValue> cache, TKey key,
+        TValue value, ConcurrentQueue<TKey> order) where TKey : notnull
+    {
+        // Use GetOrAdd to ensure we don't lose the value if already present
+        if (cache.TryAdd(key, value))
+        {
+            // Only track order for new entries
+            order.Enqueue(key);
+
+            // Use queue-based FIFO eviction when limit is exceeded
+            while (cache.Count > MaxCacheSize && order.TryDequeue(out var oldKey))
+            {
+                cache.TryRemove(oldKey, out _);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Thread-safe method to add reader plans with bounded cache size using atomic dictionary swap
+    /// </summary>
+    private void TryAddReaderPlanWithLimit(int hash, ColumnPlan[] plan)
+    {
+        // Use GetOrAdd to ensure we don't lose the value if already present
+        _readerPlans.GetOrAdd(hash, plan);
+
+        // If cache size exceeds limit, atomically swap to a new dictionary
+        if (_readerPlans.Count > MaxReaderPlans)
+        {
+            var newCache = new ConcurrentDictionary<int, ColumnPlan[]>();
+            newCache.TryAdd(hash, plan);
+            // Atomic swap - other threads will start using the new cache
+            Interlocked.Exchange(ref _readerPlans, newCache);
+        }
+    }
+
+    public void ClearCaches()
+    {
+        _readerConverters.Clear();
+        _readerConvertersOrder.Clear();
+        _readerPlans.Clear();
+        _columnListCache.Clear();
+        _columnListCacheOrder.Clear();
+        _queryCache.Clear();
+        _queryCacheOrder.Clear();
+        _whereParameterNames.Clear();
+        _whereParameterNamesOrder.Clear();
+    }
+}

--- a/pengdows.crud/EntityHelper.Core.cs
+++ b/pengdows.crud/EntityHelper.Core.cs
@@ -746,7 +746,9 @@ public partial class EntityHelper<TEntity, TRowID> :
 
     public void BuildWhereByPrimaryKey(IReadOnlyCollection<TEntity>? listOfObjects, ISqlContainer sc, string alias = "")
     {
-        BuildWhereByPrimaryKey(listOfObjects, sc, alias, _dialect);
+        var dialectProvider = sc as ISqlDialectProvider;
+        var dialect = dialectProvider?.Dialect ?? _dialect;
+        BuildWhereByPrimaryKey(listOfObjects, sc, alias, dialect);
     }
 
     public void BuildWhereByPrimaryKey(IReadOnlyCollection<TEntity>? listOfObjects, ISqlContainer sc, string alias, ISqlDialect dialect)
@@ -1093,6 +1095,7 @@ public partial class EntityHelper<TEntity, TRowID> :
 
     private async Task<TEntity?> LoadOriginalAsync(TEntity objectToUpdate, IDatabaseContext? context = null)
     {
+        var ctx = context ?? _context;
         var idValue = _idColumn!.PropertyInfo.GetValue(objectToUpdate);
         if (IsDefaultId(idValue))
         {
@@ -1111,7 +1114,7 @@ public partial class EntityHelper<TEntity, TRowID> :
                 return null;
             }
 
-            return await RetrieveOneAsync((TRowID)converted, context);
+            return await RetrieveOneAsync((TRowID)converted, ctx);
         }
         catch (InvalidCastException ex)
         {

--- a/pengdows.crud/EntityHelper.Reader.cs
+++ b/pengdows.crud/EntityHelper.Reader.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using pengdows.crud.exceptions;
+using pengdows.crud.wrappers;
+
+namespace pengdows.crud;
+
+public partial class EntityHelper<TEntity, TRowID>
+{
+    public TEntity MapReaderToObject(ITrackedReader reader)
+    {
+        var obj = new TEntity();
+
+        var plan = GetOrBuildRecordsetPlan(reader);
+        for (var idx = 0; idx < plan.Length; idx++)
+        {
+            var p = plan[idx];
+            var raw = reader.IsDBNull(p.Ordinal) ? null : reader.GetValue(p.Ordinal);
+            var coerced = p.Converter(raw);
+            try
+            {
+                p.Setter(obj, coerced);
+            }
+            catch (Exception ex)
+            {
+                var name = reader.GetName(p.Ordinal);
+                throw new InvalidValueException(
+                    $"Unable to set property from value that was stored in the database: {name} :{ex.Message}");
+            }
+        }
+
+        return obj;
+    }
+
+    private ColumnPlan[] GetOrBuildRecordsetPlan(ITrackedReader reader)
+    {
+        // Compute a stronger hash for the recordset shape: field count + names + types
+        var fieldCount = reader.FieldCount;
+        var hash = fieldCount * 397;
+        for (var i = 0; i < fieldCount; i++)
+        {
+            var name = reader.GetName(i);
+            hash = unchecked(hash * 31 + StringComparer.OrdinalIgnoreCase.GetHashCode(name));
+
+            // Include field type to strengthen hash and avoid shape collisions
+            var fieldType = reader.GetFieldType(i);
+            hash = unchecked(hash * 31 + fieldType.GetHashCode());
+        }
+
+        // Try to get existing plan from thread-safe cache
+        if (_readerPlans.TryGetValue(hash, out var existingPlan))
+        {
+            return existingPlan;
+        }
+
+        // Build new plan
+        var list = new List<ColumnPlan>(fieldCount);
+        for (var i = 0; i < fieldCount; i++)
+        {
+            var colName = reader.GetName(i);
+            if (_columnsByNameCI.TryGetValue(colName, out var column))
+            {
+                var setter = GetOrCreateSetter(column.PropertyInfo);
+                var converter = GetOrCreateReaderConverter(column);
+                list.Add(new ColumnPlan(i, setter, converter));
+            }
+        }
+
+        var plan = list.ToArray();
+
+        // Add to cache with bounded size limit
+        TryAddReaderPlanWithLimit(hash, plan);
+        return plan;
+    }
+
+    public Action<object, object?> GetOrCreateSetter(PropertyInfo prop)
+    {
+        // The generated setter casts directly; a database NULL assigned to a non-nullable property will throw.
+        // This fail-fast behavior surfaces unexpected schema mismatches immediately.
+        return _propertySetters.GetOrAdd(prop, p =>
+        {
+            var objParam = Expression.Parameter(typeof(object));
+            var valueParam = Expression.Parameter(typeof(object));
+
+            var castObj = Expression.Convert(objParam, p.DeclaringType!);
+            var castValue = Expression.Convert(valueParam, p.PropertyType);
+
+            var propertyAccess = Expression.Property(castObj, p);
+            var assignment = Expression.Assign(propertyAccess, castValue);
+
+            var lambda = Expression.Lambda<Action<object, object?>>(assignment, objParam, valueParam);
+            return lambda.Compile();
+        });
+    }
+}

--- a/pengdows.crud/EntityHelper.Reader.cs
+++ b/pengdows.crud/EntityHelper.Reader.cs
@@ -50,7 +50,7 @@ public partial class EntityHelper<TEntity, TRowID>
         }
 
         // Try to get existing plan from thread-safe cache
-        if (_readerPlans.TryGetValue(hash, out var existingPlan))
+        if (_readerPlans.TryGet(hash, out var existingPlan))
         {
             return existingPlan;
         }
@@ -70,9 +70,7 @@ public partial class EntityHelper<TEntity, TRowID>
 
         var plan = list.ToArray();
 
-        // Add to cache with bounded size limit
-        TryAddReaderPlanWithLimit(hash, plan);
-        return plan;
+        return _readerPlans.GetOrAdd(hash, _ => plan);
     }
 
     public Action<object, object?> GetOrCreateSetter(PropertyInfo prop)

--- a/pengdows.crud/EntityHelper.Sql.cs
+++ b/pengdows.crud/EntityHelper.Sql.cs
@@ -61,7 +61,7 @@ public partial class EntityHelper<TEntity, TRowID>
         var valuePlaceholders = new List<string>();
         for (var i = 0; i < insertColumns.Count; i++)
         {
-            var name = $"p{i}";
+            var name = $"i{i}";
             paramNames.Add(name);
             valuePlaceholders.Add("{P}" + name);
         }

--- a/pengdows.crud/EntityHelper.Sql.cs
+++ b/pengdows.crud/EntityHelper.Sql.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using pengdows.crud.dialects;
+
+namespace pengdows.crud;
+
+public partial class EntityHelper<TEntity, TRowID>
+{
+    private class CachedSqlTemplates
+    {
+        public string InsertSql = null!;
+        public List<IColumnInfo> InsertColumns = null!;
+        public List<string> InsertParameterNames = null!;
+        public string DeleteSql = null!;
+        public string UpdateSql = null!;
+        public List<IColumnInfo> UpdateColumns = null!;
+    }
+
+    // Neutral tokens used in cached SQL; replaced with dialect-specific tokens on retrieval
+    private const string NeutralQuotePrefix = "{Q}";
+    private const string NeutralQuoteSuffix = "{q}";
+    private const string NeutralSeparator = "{S}";
+
+    private static string WrapNeutral(string name)
+    {
+        return string.IsNullOrEmpty(name) ? string.Empty : NeutralQuotePrefix + name + NeutralQuoteSuffix;
+    }
+
+    private static string ReplaceNeutralTokens(string sql, ISqlDialect dialect)
+    {
+        if (string.IsNullOrEmpty(sql))
+        {
+            return sql;
+        }
+        return sql.Replace(NeutralQuotePrefix, dialect.QuotePrefix)
+                  .Replace(NeutralQuoteSuffix, dialect.QuoteSuffix)
+                  .Replace(NeutralSeparator, dialect.CompositeIdentifierSeparator);
+    }
+
+    private CachedSqlTemplates BuildCachedSqlTemplatesNeutral()
+    {
+        var idCol = _tableInfo.Columns.Values.FirstOrDefault(c => c.IsId)
+                     ?? throw new InvalidOperationException($"No ID column defined for {typeof(TEntity).Name}");
+
+        var insertColumns = _tableInfo.Columns.Values
+            .Where(c => !c.IsNonInsertable && (!c.IsId || c.IsIdIsWritable))
+            .Where(c => _auditValueResolver != null || (!c.IsCreatedBy && !c.IsLastUpdatedBy))
+            .Cast<IColumnInfo>()
+            .ToList();
+
+        var wrappedCols = new List<string>();
+        for (var i = 0; i < insertColumns.Count; i++)
+        {
+            wrappedCols.Add(WrapNeutral(insertColumns[i].Name));
+        }
+
+        var paramNames = new List<string>();
+        var valuePlaceholders = new List<string>();
+        for (var i = 0; i < insertColumns.Count; i++)
+        {
+            var name = $"p{i}";
+            paramNames.Add(name);
+            valuePlaceholders.Add("{P}" + name);
+        }
+
+        var insertSql =
+            $"INSERT INTO {BuildWrappedTableNameNeutral()} ({string.Join(", ", wrappedCols)}) VALUES ({string.Join(", ", valuePlaceholders)})";
+        var deleteSql =
+            $"DELETE FROM {BuildWrappedTableNameNeutral()} WHERE {WrapNeutral(idCol.Name)} = {{0}}";
+
+        var updateColumns = _tableInfo.Columns.Values
+            .Where(c => !c.IsId && !c.IsVersion && !c.IsNonUpdateable && !c.IsCreatedBy && !c.IsCreatedOn)
+            .Cast<IColumnInfo>()
+            .ToList();
+
+        var updateSql =
+            $"UPDATE {BuildWrappedTableNameNeutral()} SET {{0}} WHERE {WrapNeutral(idCol.Name)} = {{1}}";
+
+        return new CachedSqlTemplates
+        {
+            InsertSql = insertSql,
+            InsertColumns = insertColumns,
+            InsertParameterNames = paramNames,
+            DeleteSql = deleteSql,
+            UpdateSql = updateSql,
+            UpdateColumns = updateColumns
+        };
+    }
+
+    private CachedSqlTemplates GetTemplatesForDialect(ISqlDialect dialect)
+    {
+        return _templatesByDialect
+            .GetOrAdd(dialect.DatabaseType, _ => new Lazy<CachedSqlTemplates>(() =>
+            {
+                var neutral = _cachedSqlTemplates.Value;
+                string RenderParams(string sql)
+                {
+                    // Replace neutral param tokens with dialect-appropriate placeholders.
+                    // Named: {P}name -> @name or :name
+                    // Positional: {P}name -> ?
+                    return Regex.Replace(sql, "\\{P\\}([A-Za-z_][A-Za-z0-9_]*)",
+                        m => dialect.SupportsNamedParameters
+                            ? string.Concat(dialect.ParameterMarker, m.Groups[1].Value)
+                            : dialect.ParameterMarker);
+                }
+
+                return new CachedSqlTemplates
+                {
+                    InsertSql = RenderParams(ReplaceNeutralTokens(neutral.InsertSql, dialect)),
+                    InsertColumns = neutral.InsertColumns,
+                    InsertParameterNames = neutral.InsertParameterNames,
+                    DeleteSql = ReplaceNeutralTokens(neutral.DeleteSql, dialect),
+                    UpdateSql = ReplaceNeutralTokens(neutral.UpdateSql, dialect),
+                    UpdateColumns = neutral.UpdateColumns
+                };
+            }))
+            .Value;
+    }
+
+    private string BuildWrappedTableNameNeutral()
+    {
+        if (string.IsNullOrWhiteSpace(_tableInfo.Schema))
+        {
+            return WrapNeutral(_tableInfo.Name);
+        }
+
+        var sb = new StringBuilder();
+        sb.Append(WrapNeutral(_tableInfo.Schema));
+        sb.Append(NeutralSeparator);
+        sb.Append(WrapNeutral(_tableInfo.Name));
+        return sb.ToString();
+    }
+}

--- a/pengdows.crud/SqlContainer.cs
+++ b/pengdows.crud/SqlContainer.cs
@@ -17,7 +17,7 @@ using pengdows.crud.strategies.proc;
 
 namespace pengdows.crud;
 
-public class SqlContainer : SafeAsyncDisposableBase, ISqlContainer
+public class SqlContainer : SafeAsyncDisposableBase, ISqlContainer, ISqlDialectProvider
 {
     private readonly IDatabaseContext _context;
     private readonly ISqlDialect _dialect;
@@ -25,6 +25,8 @@ public class SqlContainer : SafeAsyncDisposableBase, ISqlContainer
     private readonly ILogger<ISqlContainer> _logger;
     private readonly IDictionary<string, DbParameter> _parameters = new OrderedDictionary<string, DbParameter>();
     private int _outputParameterCount;
+
+    ISqlDialect ISqlDialectProvider.Dialect => _dialect;
 
     internal SqlContainer(IDatabaseContext context, string? query = "", ILogger<ISqlContainer>? logger = null)
     {

--- a/pengdows.crud/internal/BoundedCache.cs
+++ b/pengdows.crud/internal/BoundedCache.cs
@@ -1,0 +1,50 @@
+using System.Collections.Concurrent;
+
+namespace pengdows.crud.@internal;
+
+internal sealed class BoundedCache<TKey, TValue> where TKey : notnull
+{
+    private readonly int _max;
+    private readonly ConcurrentDictionary<TKey, TValue> _map = new();
+    private readonly ConcurrentQueue<TKey> _order = new();
+
+    public BoundedCache(int max)
+    {
+        _max = Math.Max(1, max);
+    }
+
+    public TValue GetOrAdd(TKey key, Func<TKey, TValue> factory)
+    {
+        if (_map.TryGetValue(key, out var v))
+        {
+            return v;
+        }
+
+        var created = factory(key);
+        if (_map.TryAdd(key, created))
+        {
+            _order.Enqueue(key);
+            while (_map.Count > _max && _order.TryDequeue(out var old))
+            {
+                _map.TryRemove(old, out _);
+            }
+        }
+
+        return created;
+    }
+
+    public bool TryGet(TKey key, out TValue v)
+    {
+        return _map.TryGetValue(key, out v!);
+    }
+
+    public void Clear()
+    {
+        while (_order.TryDequeue(out _))
+        {
+        }
+
+        _map.Clear();
+    }
+}
+

--- a/pengdows.crud/internal/ClauseCounters.cs
+++ b/pengdows.crud/internal/ClauseCounters.cs
@@ -1,0 +1,18 @@
+namespace pengdows.crud.@internal;
+
+internal sealed class ClauseCounters
+{
+    private int _set;
+    private int _where;
+    private int _join;
+    private int _key;
+    private int _ver;
+    private int _ins;
+
+    public string NextSet() => $"s{_set++}";
+    public string NextWhere() => $"w{_where++}";
+    public string NextJoin() => $"j{_join++}";
+    public string NextKey() => $"k{_key++}";
+    public string NextVer() => $"v{_ver++}";
+    public string NextIns() => $"i{_ins++}";
+}


### PR DESCRIPTION
## Summary
- start breaking `EntityHelper` into partials
- extract reader mapping methods
- extract caching utilities and SQL template helpers

## Testing
- `dotnet build pengdows.crud.sln -c Release`
- `dotnet test -c Release --results-directory TestResults --logger trx`


------
https://chatgpt.com/codex/tasks/task_e_68ba25827fc0832589008f8047e2e9d9