### PR TITLE
Expand DbMode auto-selection coverage

### DIFF
--- a/pengdows.crud.Tests/DbModeCoercionLoggingTests.cs
+++ b/pengdows.crud.Tests/DbModeCoercionLoggingTests.cs
@@ -14,7 +14,7 @@ namespace pengdows.crud.Tests;
 public class DbModeCoercionLoggingTests
 {
     [Fact]
-    public void SqliteSharedMemory_BestMode_CoercesToSingleWriter_WithWarning()
+    public void SqliteSharedMemory_BestMode_AutoSelectsSingleWriter_WithInfo()
     {
         var provider = new ListLoggerProvider();
         using var lf = new LoggerFactory(new[] { provider });
@@ -26,11 +26,12 @@ public class DbModeCoercionLoggingTests
         };
         using var ctx = new DatabaseContext(cfg, new fakeDbFactory(SupportedDatabase.Sqlite), lf);
         Assert.Equal(DbMode.SingleWriter, ctx.ConnectionMode);
-        Assert.Contains(provider.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("DbMode override"));
+        Assert.Contains(provider.Entries, e => e.Level == LogLevel.Information && e.Message.Contains("DbMode auto-selection"));
+        Assert.DoesNotContain(provider.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("DbMode override"));
     }
 
     [Fact]
-    public void DuckDbFile_BestMode_CoercesToSingleWriter_WithWarning()
+    public void DuckDbFile_BestMode_AutoSelectsSingleWriter_WithInfo()
     {
         var provider = new ListLoggerProvider();
         using var lf = new LoggerFactory(new[] { provider });
@@ -42,11 +43,61 @@ public class DbModeCoercionLoggingTests
         };
         using var ctx = new DatabaseContext(cfg, new fakeDbFactory(SupportedDatabase.DuckDB), lf);
         Assert.Equal(DbMode.SingleWriter, ctx.ConnectionMode);
+        Assert.Contains(provider.Entries, e => e.Level == LogLevel.Information && e.Message.Contains("DbMode auto-selection"));
+        Assert.DoesNotContain(provider.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("DbMode override"));
+    }
+
+    [Fact]
+    public void DuckDbFile_StandardMode_CoercesToSingleWriter_WithWarning()
+    {
+        var provider = new ListLoggerProvider();
+        using var lf = new LoggerFactory(new[] { provider });
+        var cfg = new DatabaseContextConfiguration
+        {
+            ConnectionString = "Data Source=file.duckdb;EmulatedProduct=DuckDB",
+            ProviderName = SupportedDatabase.DuckDB.ToString(),
+            DbMode = DbMode.Standard
+        };
+        using var ctx = new DatabaseContext(cfg, new fakeDbFactory(SupportedDatabase.DuckDB), lf);
+        Assert.Equal(DbMode.SingleWriter, ctx.ConnectionMode);
         Assert.Contains(provider.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("DbMode override"));
     }
 
     [Fact]
-    public void SqlServer_BestMode_PrefersStandard_WithWarning()
+    public void SqliteSharedMemory_StandardMode_CoercesToSingleWriter_WithWarning()
+    {
+        var provider = new ListLoggerProvider();
+        using var lf = new LoggerFactory(new[] { provider });
+        var cfg = new DatabaseContextConfiguration
+        {
+            ConnectionString = "Data Source=file:shared?mode=memory&cache=shared;EmulatedProduct=Sqlite",
+            ProviderName = SupportedDatabase.Sqlite.ToString(),
+            DbMode = DbMode.Standard
+        };
+        using var ctx = new DatabaseContext(cfg, new fakeDbFactory(SupportedDatabase.Sqlite), lf);
+        Assert.Equal(DbMode.SingleWriter, ctx.ConnectionMode);
+        Assert.Contains(provider.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("DbMode override"));
+    }
+
+    [Fact]
+    public void SqliteFile_BestMode_AutoSelectsSingleWriter_WithInfo()
+    {
+        var provider = new ListLoggerProvider();
+        using var lf = new LoggerFactory(new[] { provider });
+        var cfg = new DatabaseContextConfiguration
+        {
+            ConnectionString = "Data Source=file.db;EmulatedProduct=Sqlite",
+            ProviderName = SupportedDatabase.Sqlite.ToString(),
+            DbMode = DbMode.Best
+        };
+        using var ctx = new DatabaseContext(cfg, new fakeDbFactory(SupportedDatabase.Sqlite), lf);
+        Assert.Equal(DbMode.SingleWriter, ctx.ConnectionMode);
+        Assert.Contains(provider.Entries, e => e.Level == LogLevel.Information && e.Message.Contains("DbMode auto-selection"));
+        Assert.DoesNotContain(provider.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("DbMode override"));
+    }
+
+    [Fact]
+    public void SqlServer_BestMode_AutoSelectsStandard_WithInfo()
     {
         var provider = new ListLoggerProvider();
         using var lf = new LoggerFactory(new[] { provider });
@@ -58,6 +109,121 @@ public class DbModeCoercionLoggingTests
         };
         using var ctx = new DatabaseContext(cfg, new fakeDbFactory(SupportedDatabase.SqlServer), lf);
         Assert.Equal(DbMode.Standard, ctx.ConnectionMode);
+        Assert.Contains(provider.Entries, e => e.Level == LogLevel.Information && e.Message.Contains("DbMode auto-selection"));
+        Assert.DoesNotContain(provider.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("DbMode override"));
+    }
+
+    [Fact]
+    public void SqliteFile_StandardMode_CoercesToSingleWriter_WithWarning()
+    {
+        var provider = new ListLoggerProvider();
+        using var lf = new LoggerFactory(new[] { provider });
+        var cfg = new DatabaseContextConfiguration
+        {
+            ConnectionString = "Data Source=file.db;EmulatedProduct=Sqlite",
+            ProviderName = SupportedDatabase.Sqlite.ToString(),
+            DbMode = DbMode.Standard
+        };
+        using var ctx = new DatabaseContext(cfg, new fakeDbFactory(SupportedDatabase.Sqlite), lf);
+        Assert.Equal(DbMode.SingleWriter, ctx.ConnectionMode);
+        Assert.Contains(provider.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("DbMode override"));
+    }
+
+    [Fact]
+    public void SqlServerLocalDb_BestMode_AutoSelectsKeepAlive_WithInfo()
+    {
+        var provider = new ListLoggerProvider();
+        using var lf = new LoggerFactory(new[] { provider });
+        var cfg = new DatabaseContextConfiguration
+        {
+            ConnectionString = "Server=(localdb)\\mssqllocaldb;Database=TestDb;EmulatedProduct=SqlServer",
+            ProviderName = SupportedDatabase.SqlServer.ToString(),
+            DbMode = DbMode.Best
+        };
+        using var ctx = new DatabaseContext(cfg, new fakeDbFactory(SupportedDatabase.SqlServer), lf);
+        Assert.Equal(DbMode.KeepAlive, ctx.ConnectionMode);
+        Assert.Contains(provider.Entries, e => e.Level == LogLevel.Information && e.Message.Contains("DbMode auto-selection"));
+        Assert.DoesNotContain(provider.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("DbMode override"));
+    }
+
+    [Fact]
+    public void SqlServerLocalDb_StandardMode_CoercesToKeepAlive_WithWarning()
+    {
+        var provider = new ListLoggerProvider();
+        using var lf = new LoggerFactory(new[] { provider });
+        var cfg = new DatabaseContextConfiguration
+        {
+            ConnectionString = "Server=(localdb)\\mssqllocaldb;Database=TestDb;EmulatedProduct=SqlServer",
+            ProviderName = SupportedDatabase.SqlServer.ToString(),
+            DbMode = DbMode.Standard
+        };
+        using var ctx = new DatabaseContext(cfg, new fakeDbFactory(SupportedDatabase.SqlServer), lf);
+        Assert.Equal(DbMode.KeepAlive, ctx.ConnectionMode);
+        Assert.Contains(provider.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("DbMode override"));
+    }
+
+    [Fact]
+    public void SqlServer_KeepAliveMode_CoercesToStandard_WithWarning()
+    {
+        var provider = new ListLoggerProvider();
+        using var lf = new LoggerFactory(new[] { provider });
+        var cfg = new DatabaseContextConfiguration
+        {
+            ConnectionString = "Data Source=test;EmulatedProduct=SqlServer",
+            ProviderName = SupportedDatabase.SqlServer.ToString(),
+            DbMode = DbMode.KeepAlive
+        };
+        using var ctx = new DatabaseContext(cfg, new fakeDbFactory(SupportedDatabase.SqlServer), lf);
+        Assert.Equal(DbMode.Standard, ctx.ConnectionMode);
+        Assert.Contains(provider.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("DbMode override"));
+    }
+
+    [Fact]
+    public void FirebirdEmbedded_BestMode_AutoSelectsSingleConnection_WithInfo()
+    {
+        var provider = new ListLoggerProvider();
+        using var lf = new LoggerFactory(new[] { provider });
+        var cfg = new DatabaseContextConfiguration
+        {
+            ConnectionString = "Database=C:/data/test.fdb;ServerType=Embedded;EmulatedProduct=Firebird",
+            ProviderName = SupportedDatabase.Firebird.ToString(),
+            DbMode = DbMode.Best
+        };
+        using var ctx = new DatabaseContext(cfg, new fakeDbFactory(SupportedDatabase.Firebird), lf);
+        Assert.Equal(DbMode.SingleConnection, ctx.ConnectionMode);
+        Assert.Contains(provider.Entries, e => e.Level == LogLevel.Information && e.Message.Contains("DbMode auto-selection"));
+        Assert.DoesNotContain(provider.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("DbMode override"));
+    }
+
+    [Fact]
+    public void FirebirdEmbedded_StandardMode_CoercesToSingleConnection_WithWarning()
+    {
+        var provider = new ListLoggerProvider();
+        using var lf = new LoggerFactory(new[] { provider });
+        var cfg = new DatabaseContextConfiguration
+        {
+            ConnectionString = "Database=C:/data/test.fdb;ServerType=Embedded;EmulatedProduct=Firebird",
+            ProviderName = SupportedDatabase.Firebird.ToString(),
+            DbMode = DbMode.Standard
+        };
+        using var ctx = new DatabaseContext(cfg, new fakeDbFactory(SupportedDatabase.Firebird), lf);
+        Assert.Equal(DbMode.SingleConnection, ctx.ConnectionMode);
+        Assert.Contains(provider.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("DbMode override"));
+    }
+
+    [Fact]
+    public void SqliteIsolatedMemory_KeepAliveMode_CoercesToSingleConnection_WithWarning()
+    {
+        var provider = new ListLoggerProvider();
+        using var lf = new LoggerFactory(new[] { provider });
+        var cfg = new DatabaseContextConfiguration
+        {
+            ConnectionString = "Data Source=:memory:;EmulatedProduct=Sqlite",
+            ProviderName = SupportedDatabase.Sqlite.ToString(),
+            DbMode = DbMode.KeepAlive
+        };
+        using var ctx = new DatabaseContext(cfg, new fakeDbFactory(SupportedDatabase.Sqlite), lf);
+        Assert.Equal(DbMode.SingleConnection, ctx.ConnectionMode);
         Assert.Contains(provider.Entries, e => e.Level == LogLevel.Warning && e.Message.Contains("DbMode override"));
     }
 }

--- a/pengdows.crud/strategies/connection/ConnectionStrategyFactory.cs
+++ b/pengdows.crud/strategies/connection/ConnectionStrategyFactory.cs
@@ -36,15 +36,8 @@ namespace pengdows.crud.strategies.connection;
 /// </summary>
 internal static class ConnectionStrategyFactory
 {
-    public static  IConnectionStrategy Create(DatabaseContext context, DbMode mode)
+    public static IConnectionStrategy Create(DatabaseContext context, DbMode mode)
     {
-        // If an embedded in-memory engine coerces the mode to SingleConnection, but the user
-        // explicitly requested KeepAlive, prefer KeepAlive semantics while reporting SingleConnection
-        if (mode == DbMode.SingleConnection && context.OriginalUserMode == DbMode.KeepAlive)
-        {
-            return new KeepAliveConnectionStrategy(context);
-        }
-
         return mode switch
         {
             DbMode.Standard => new StandardConnectionStrategy(context),


### PR DESCRIPTION
## Summary
- refactor the DbMode coercion helper to switch on provider types so Best-mode auto-selection consistently maps to safe strategies
- add positive and negative logging tests that cover SQLite shared/file, DuckDB file, LocalDb, Firebird embedded, and in-memory coercion scenarios

## Testing
- `dotnet test -c Release` *(fails: `dotnet` command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c83d7d701483258e90b524f402e35f