### PR TITLE
perf: cache property lookups in data reader mapper

### DIFF
--- a/pengdows.crud.Tests/DataReaderMapperTests.cs
+++ b/pengdows.crud.Tests/DataReaderMapperTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Threading.Tasks;
 using pengdows.crud.attributes;
+using pengdows.crud.enums;
 using pengdows.crud.fakeDb;
 using Xunit;
 
@@ -211,6 +212,42 @@ public class DataReaderMapperTests
     }
 
     [Fact]
+    public async Task LoadAsync_WhenSwitchingColumnsOnlyOption_RespectsCachedLookup()
+    {
+        var defaultReader = new fakeDbDataReader(new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["Name"] = "Alice",
+                ["Age"] = 45
+            }
+        });
+
+        var defaultResult = await DataReaderMapper.LoadAsync<ColumnsOnlyEntity>(defaultReader, MapperOptions.Default);
+
+        Assert.Single(defaultResult);
+        Assert.Equal("Alice", defaultResult[0].Name);
+        Assert.Equal(45, defaultResult[0].Age);
+
+        var columnsOnlyReader = new fakeDbDataReader(new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["Name"] = "Bob",
+                ["Age"] = 51
+            }
+        });
+
+        var columnsOnlyResult = await DataReaderMapper.LoadAsync<ColumnsOnlyEntity>(
+            columnsOnlyReader,
+            new MapperOptions(ColumnsOnly: true));
+
+        Assert.Single(columnsOnlyResult);
+        Assert.Equal("Bob", columnsOnlyResult[0].Name);
+        Assert.Equal(0, columnsOnlyResult[0].Age);
+    }
+
+    [Fact]
     public async Task LoadObjectsFromDataReaderAsync_MapsEnumFromString()
     {
         var reader = new fakeDbDataReader(new[]
@@ -259,6 +296,201 @@ public class DataReaderMapperTests
             () => DataReaderMapper.LoadAsync<EnumEntity>(reader, new MapperOptions(Strict: true)));
     }
 
+    [Fact]
+    public async Task LoadAsync_WithTypeConversion_UsesCoercion()
+    {
+        var reader = new fakeDbDataReader(new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["Age"] = "42"
+            }
+        });
+
+        var result = await DataReaderMapper.LoadAsync<TypeConversionEntity>(reader, MapperOptions.Default);
+
+        Assert.Single(result);
+        Assert.Equal(42, result[0].Age);
+    }
+
+    [Fact]
+    public async Task LoadObjectsFromDataReaderAsync_DirectAssignment_UsesGetFieldValue()
+    {
+        var reader = new TrackingFieldAccessReader(new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["Age"] = 37
+            }
+        });
+
+        var result = await DataReaderMapper.LoadObjectsFromDataReaderAsync<DirectEntity>(reader);
+
+        Assert.Single(result);
+        Assert.Equal(37, result[0].Age);
+        Assert.Equal(1, reader.GetValueCallCount);
+        Assert.Equal(1, reader.GetFieldValueCallCount);
+    }
+
+    [Fact]
+    public async Task LoadObjectsFromDataReaderAsync_CoercionPath_UsesGetValue()
+    {
+        var reader = new TrackingFieldAccessReader(new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["Age"] = "58"
+            }
+        });
+
+        var result = await DataReaderMapper.LoadObjectsFromDataReaderAsync<TypeConversionEntity>(reader);
+
+        Assert.Single(result);
+        Assert.Equal(58, result[0].Age);
+        Assert.Equal(2, reader.GetValueCallCount);
+        Assert.Equal(0, reader.GetFieldValueCallCount);
+    }
+
+    [Fact]
+    public async Task LoadObjectsFromDataReaderAsync_WhenColumnTypeRemainsStable_ReusesTypedGetter()
+    {
+        var firstReader = new StrictTrackingFieldAccessReader(new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["Age"] = 64
+            }
+        });
+
+        var secondReader = new StrictTrackingFieldAccessReader(new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["Age"] = 65
+            }
+        });
+
+        var firstResult = await DataReaderMapper.LoadObjectsFromDataReaderAsync<DirectEntity>(firstReader);
+        var secondResult = await DataReaderMapper.LoadObjectsFromDataReaderAsync<DirectEntity>(secondReader);
+
+        Assert.Single(firstResult);
+        Assert.Equal(64, firstResult[0].Age);
+        Assert.Single(secondResult);
+        Assert.Equal(65, secondResult[0].Age);
+        Assert.Equal(0, firstReader.GetFieldValueFailures);
+        Assert.True(firstReader.GetFieldValueCallCount >= 1);
+        Assert.Equal(0, secondReader.GetFieldValueFailures);
+        Assert.True(secondReader.GetFieldValueCallCount >= 1);
+    }
+
+    [Fact]
+    public async Task LoadObjectsFromDataReaderAsync_WhenColumnTypeChanges_RebuildsPlanAndUsesCoercion()
+    {
+        var firstReader = new StrictTrackingFieldAccessReader(new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["Age"] = 70
+            }
+        });
+
+        var secondReader = new StrictTrackingFieldAccessReader(new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["Age"] = "71"
+            }
+        });
+
+        var firstResult = await DataReaderMapper.LoadObjectsFromDataReaderAsync<DirectEntity>(firstReader);
+        Assert.Single(firstResult);
+        Assert.Equal(70, firstResult[0].Age);
+        Assert.Equal(0, firstReader.GetFieldValueFailures);
+        Assert.True(firstReader.GetFieldValueCallCount >= 1);
+
+        var secondResult = await DataReaderMapper.LoadObjectsFromDataReaderAsync<DirectEntity>(secondReader);
+
+        Assert.Single(secondResult);
+        Assert.Equal(71, secondResult[0].Age);
+        Assert.Equal(0, secondReader.GetFieldValueCallCount);
+        Assert.True(secondReader.GetValueCallCount >= 2);
+        Assert.Equal(0, secondReader.GetFieldValueFailures);
+    }
+
+    [Fact]
+    public async Task LoadAsync_WithEnumSetNullAndLog_UsesConfiguredBehavior()
+    {
+        var reader = new fakeDbDataReader(new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["NullableState"] = "invalid",
+                ["RequiredState"] = "invalid"
+            }
+        });
+
+        var options = new MapperOptions(EnumMode: EnumParseFailureMode.SetNullAndLog);
+        var result = await DataReaderMapper.LoadAsync<EnumModeEntity>(reader, options);
+
+        Assert.Single(result);
+        Assert.Null(result[0].NullableState);
+        Assert.Equal(default(SampleState), result[0].RequiredState);
+    }
+
+    [Fact]
+    public async Task LoadAsync_WithEnumSetDefaultValue_UsesConfiguredBehavior()
+    {
+        var reader = new fakeDbDataReader(new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["NullableState"] = 999,
+                ["RequiredState"] = 999
+            }
+        });
+
+        var options = new MapperOptions(EnumMode: EnumParseFailureMode.SetDefaultValue);
+        var result = await DataReaderMapper.LoadAsync<EnumModeEntity>(reader, options);
+
+        Assert.Single(result);
+        Assert.Equal(default(SampleState?), result[0].NullableState);
+        Assert.Equal(default(SampleState), result[0].RequiredState);
+    }
+
+    [Fact]
+    public async Task LoadAsync_WhenGetFieldTypeThrows_FallsBackToObject()
+    {
+        var reader = new ThrowingFieldTypeReader(new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["Age"] = 21
+            }
+        });
+
+        var result = await DataReaderMapper.LoadAsync<TypeConversionEntity>(reader, MapperOptions.Default);
+
+        Assert.Single(result);
+        Assert.Equal(21, result[0].Age);
+    }
+
+    [Fact]
+    public async Task LoadAsync_ColumnsOnly_WithDuplicateColumnNames_ThrowsArgumentException()
+    {
+        var reader = new fakeDbDataReader(new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["Alias"] = "First"
+            }
+        });
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => DataReaderMapper.LoadAsync<DuplicateColumnNamesEntity>(
+                reader,
+                new MapperOptions(ColumnsOnly: true)));
+    }
+
     private class SampleEntity
     {
         public string Name { get; set; }
@@ -287,5 +519,126 @@ public class DataReaderMapperTests
     private class EnumEntity
     {
         public SampleState State { get; set; }
+    }
+
+    private class TypeConversionEntity
+    {
+        public int Age { get; set; }
+    }
+
+    private class EnumModeEntity
+    {
+        public SampleState? NullableState { get; set; }
+        public SampleState RequiredState { get; set; }
+    }
+
+    private class DuplicateColumnNamesEntity
+    {
+        [Column("Alias", DbType.String)]
+        public string? First { get; set; }
+
+        [Column("Alias", DbType.String)]
+        public string? Second { get; set; }
+    }
+
+    private class DirectEntity
+    {
+        public int Age { get; set; }
+    }
+
+    private sealed class ThrowingFieldTypeReader : fakeDbDataReader
+    {
+        public ThrowingFieldTypeReader(IEnumerable<Dictionary<string, object>> rows)
+            : base(rows)
+        {
+        }
+
+        public override Type GetFieldType(int ordinal)
+        {
+            throw new InvalidOperationException("Simulated failure.");
+        }
+    }
+
+    private sealed class TrackingFieldAccessReader : fakeDbDataReader
+    {
+        public TrackingFieldAccessReader(IEnumerable<Dictionary<string, object>> rows)
+            : base(rows)
+        {
+        }
+
+        public int GetValueCallCount { get; private set; }
+
+        public int GetFieldValueCallCount { get; private set; }
+
+        public override object GetValue(int i)
+        {
+            GetValueCallCount++;
+            return base.GetValue(i);
+        }
+
+        public override T GetFieldValue<T>(int ordinal)
+        {
+            GetFieldValueCallCount++;
+            var value = base.GetValue(ordinal);
+            if (value is T typed)
+            {
+                return typed;
+            }
+
+            return (T)Convert.ChangeType(value, typeof(T));
+        }
+    }
+
+    private sealed class StrictTrackingFieldAccessReader : fakeDbDataReader
+    {
+        private bool _suppressValueCount;
+
+        public StrictTrackingFieldAccessReader(IEnumerable<Dictionary<string, object>> rows)
+            : base(rows)
+        {
+        }
+
+        public int GetValueCallCount { get; private set; }
+
+        public int GetFieldValueCallCount { get; private set; }
+
+        public int GetFieldValueFailures { get; private set; }
+
+        public override object GetValue(int i)
+        {
+            if (!_suppressValueCount)
+            {
+                GetValueCallCount++;
+            }
+
+            return base.GetValue(i);
+        }
+
+        public override Type GetFieldType(int ordinal)
+        {
+            try
+            {
+                _suppressValueCount = true;
+                return base.GetFieldType(ordinal);
+            }
+            finally
+            {
+                _suppressValueCount = false;
+            }
+        }
+
+        public override T GetFieldValue<T>(int ordinal)
+        {
+            GetFieldValueCallCount++;
+            var value = base.GetValue(ordinal);
+            if (value is T typed)
+            {
+                return typed;
+            }
+
+            GetFieldValueFailures++;
+            throw new InvalidCastException(
+                $"Cannot convert value of type {value?.GetType().FullName ?? "null"} to {typeof(T).FullName}.");
+        }
     }
 }

--- a/pengdows.crud.Tests/TypeCoercionHelperTests.cs
+++ b/pengdows.crud.Tests/TypeCoercionHelperTests.cs
@@ -103,6 +103,21 @@ public class TypeCoercionHelperTests
     }
 
     [Fact]
+    public void Coerce_SingleCharacterBoolean_TrueBranch()
+    {
+        var result = TypeCoercionHelper.Coerce("Y", typeof(string), typeof(bool));
+
+        Assert.Equal(true, result);
+    }
+
+    [Fact]
+    public void Coerce_SingleCharacterBoolean_InvalidCharacter_Throws()
+    {
+        Assert.Throws<InvalidCastException>(() =>
+            TypeCoercionHelper.Coerce('x', typeof(char), typeof(bool)));
+    }
+
+    [Fact]
     public void Coerce_JsonToObject_ParsesCorrectly()
     {
         var json = "{\"Name\":\"Test\"}";

--- a/pengdows.crud/DataReaderMapper.cs
+++ b/pengdows.crud/DataReaderMapper.cs
@@ -1,11 +1,14 @@
 #region
 
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.Extensions.Logging;
 using pengdows.crud.attributes;
 
 #endregion
@@ -16,8 +19,10 @@ public sealed class DataReaderMapper : IDataReaderMapper
 {
     public static readonly IDataReaderMapper Instance = new DataReaderMapper();
 
-    private static readonly ConcurrentDictionary<PropertyInfo, Action<object, object?>> _setterCache = new();
+    private static readonly ConcurrentDictionary<SetterCacheKey, Action<object, DbDataReader>> _setterCache = new();
     private static readonly ConcurrentDictionary<(Type Type, string Schema, MapperOptions Options), MapperPlan> _planCache = new();
+    private static readonly ConcurrentDictionary<PropertyLookupCacheKey, IReadOnlyDictionary<string, PropertyInfo>> _propertyLookupCache = new();
+    private static readonly MethodInfo _getFieldValueGenericMethod = ResolveGetFieldValueMethod();
 
     public static Task<List<T>> LoadObjectsFromDataReaderAsync<T>(
         IDataReader reader,
@@ -117,17 +122,14 @@ public sealed class DataReaderMapper : IDataReaderMapper
             for (var i = 0; i < plan.Ordinals.Length; i++)
             {
                 var ordinal = plan.Ordinals[i];
-                if (await rdr.IsDBNullAsync(ordinal, cancellationToken).ConfigureAwait(false))
+                if (rdr.IsDBNull(ordinal))
                 {
                     continue;
                 }
 
                 try
                 {
-                    var raw = await rdr.GetFieldValueAsync<object>(ordinal, cancellationToken)
-                        .ConfigureAwait(false);
-                    var coerced = plan.Coercers[i](raw);
-                    plan.Setters[i](obj, coerced);
+                    plan.Setters[i](obj, rdr);
                 }
                 catch (Exception ex)
                 {
@@ -147,23 +149,10 @@ public sealed class DataReaderMapper : IDataReaderMapper
     private static MapperPlan BuildPlan<T>(DbDataReader reader, MapperOptions options)
     {
         var type = typeof(T);
-        var props = type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.SetProperty);
-
-        IEnumerable<PropertyInfo> candidates = props;
-        if (options.ColumnsOnly)
-        {
-            candidates = candidates.Where(p => p.GetCustomAttribute<ColumnAttribute>() != null);
-        }
-
-        var propertyLookup = options.ColumnsOnly
-            ? candidates.ToDictionary(
-                p => p.GetCustomAttribute<ColumnAttribute>()!.Name,
-                StringComparer.OrdinalIgnoreCase)
-            : candidates.ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
+        var propertyLookup = GetPropertyLookup(type, options);
 
         var ordinals = new List<int>();
-        var setters = new List<Action<object, object?>>();
-        var coercers = new List<Func<object, object?>>();
+        var setters = new List<Action<object, DbDataReader>>();
         var properties = new List<PropertyInfo>();
 
         for (var i = 0; i < reader.FieldCount; i++)
@@ -178,11 +167,9 @@ public sealed class DataReaderMapper : IDataReaderMapper
             if (propertyLookup.TryGetValue(name, out var prop))
             {
                 ordinals.Add(i);
-                setters.Add(GetOrCreateSetter(prop));
-                coercers.Add(value =>
-                    Utils.IsNullOrDbNull(value)
-                        ? null
-                        : TypeCoercionHelper.Coerce(value, value.GetType(), prop.PropertyType));
+                var fieldType = ResolveFieldType(reader, i);
+                var requiresCoercion = RequiresCoercion(fieldType, prop.PropertyType);
+                setters.Add(GetOrCreateSetter(prop, fieldType, requiresCoercion, options.EnumMode, i));
                 properties.Add(prop);
             }
         }
@@ -190,43 +177,263 @@ public sealed class DataReaderMapper : IDataReaderMapper
         return new MapperPlan(
             ordinals.ToArray(),
             properties.ToArray(),
-            setters.ToArray(),
-            coercers.ToArray());
+            setters.ToArray());
     }
 
-    private static string BuildSchemaHash(IDataRecord reader)
+    private static string BuildSchemaHash(DbDataReader reader)
     {
-        var names = new string[reader.FieldCount];
+        var builder = new StringBuilder();
         for (var i = 0; i < reader.FieldCount; i++)
         {
-            names[i] = reader.GetName(i);
+            if (i > 0)
+            {
+                builder.Append('|');
+            }
+
+            builder.Append(reader.GetName(i));
+            builder.Append(':');
+            var fieldType = ResolveFieldType(reader, i);
+            builder.Append(fieldType.AssemblyQualifiedName ?? fieldType.FullName ?? fieldType.Name);
         }
 
-        return string.Join("|", names);
+        return builder.ToString();
     }
 
-    private static Action<object, object?> GetOrCreateSetter(PropertyInfo prop)
+    private static Action<object, DbDataReader> GetOrCreateSetter(
+        PropertyInfo prop,
+        Type fieldType,
+        bool requiresCoercion,
+        EnumParseFailureMode enumMode,
+        int ordinal)
     {
-        return _setterCache.GetOrAdd(prop, p =>
-        {
-            var objParam = Expression.Parameter(typeof(object));
-            var valueParam = Expression.Parameter(typeof(object));
-
-            var castObj = Expression.Convert(objParam, p.DeclaringType!);
-            var castValue = Expression.Convert(valueParam, p.PropertyType);
-
-            var propertyAccess = Expression.Property(castObj, p);
-            var assignment = Expression.Assign(propertyAccess, castValue);
-
-            var lambda = Expression.Lambda<Action<object, object?>>(assignment, objParam, valueParam);
-            return lambda.Compile();
-        });
+        var key = new SetterCacheKey(prop, fieldType, requiresCoercion, enumMode, ordinal);
+        return _setterCache.GetOrAdd(key, static k => CompileSetter(k));
     }
+
+    private static Action<object, DbDataReader> CompileSetter(SetterCacheKey key)
+    {
+        var objParam = Expression.Parameter(typeof(object), "target");
+        var readerParam = Expression.Parameter(typeof(DbDataReader), "reader");
+
+        var typedTarget = Expression.Convert(objParam, key.Property.DeclaringType!);
+        var propertyAccess = Expression.Property(typedTarget, key.Property);
+
+        Expression valueExpression;
+        if (key.RequiresCoercion)
+        {
+            var getValueMethod = typeof(DbDataReader).GetMethod(nameof(DbDataReader.GetValue))!;
+            var rawValue = Expression.Call(readerParam, getValueMethod, Expression.Constant(key.Ordinal));
+            valueExpression = Expression.Convert(
+                Expression.Call(
+                    typeof(DataReaderMapper),
+                    nameof(CoerceValue),
+                    Type.EmptyTypes,
+                    rawValue,
+                    Expression.Constant(key.Property, typeof(PropertyInfo)),
+                    Expression.Constant(key.FieldType, typeof(Type)),
+                    Expression.Constant(key.EnumMode, typeof(EnumParseFailureMode))),
+                key.Property.PropertyType);
+        }
+        else
+        {
+            Expression rawValue;
+            if (key.FieldType == typeof(object))
+            {
+                var getValueMethod = typeof(DbDataReader).GetMethod(nameof(DbDataReader.GetValue))!;
+                rawValue = Expression.Call(readerParam, getValueMethod, Expression.Constant(key.Ordinal));
+            }
+            else
+            {
+                var getFieldValueMethod = _getFieldValueGenericMethod.MakeGenericMethod(key.FieldType);
+                rawValue = Expression.Call(readerParam, getFieldValueMethod, Expression.Constant(key.Ordinal));
+            }
+
+            valueExpression = key.Property.PropertyType == key.FieldType
+                ? rawValue
+                : Expression.Convert(rawValue, key.Property.PropertyType);
+        }
+
+        var assignment = Expression.Assign(propertyAccess, valueExpression);
+        var lambda = Expression.Lambda<Action<object, DbDataReader>>(assignment, objParam, readerParam);
+        return lambda.Compile();
+    }
+
+    private static bool RequiresCoercion(Type fieldType, Type propertyType)
+    {
+        var targetType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
+        if (targetType.IsAssignableFrom(fieldType))
+        {
+            return false;
+        }
+
+        if (targetType.IsEnum)
+        {
+            return true;
+        }
+
+        if (targetType == typeof(object))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static Type ResolveFieldType(DbDataReader reader, int ordinal)
+    {
+        try
+        {
+            return reader.GetFieldType(ordinal);
+        }
+        catch (InvalidOperationException)
+        {
+            return typeof(object);
+        }
+    }
+
+    private static object? CoerceValue(
+        object? value,
+        PropertyInfo property,
+        Type fieldType,
+        EnumParseFailureMode enumMode)
+    {
+        if (Utils.IsNullOrDbNull(value))
+        {
+            return null;
+        }
+
+        try
+        {
+            return TypeCoercionHelper.Coerce(value!, fieldType, property.PropertyType);
+        }
+        catch (Exception ex) when (TryHandleEnumFailure(value!, property, enumMode, ex, out var handled))
+        {
+            return handled;
+        }
+    }
+
+    private static bool TryHandleEnumFailure(
+        object value,
+        PropertyInfo property,
+        EnumParseFailureMode enumMode,
+        Exception exception,
+        out object? result)
+    {
+        var enumType = Nullable.GetUnderlyingType(property.PropertyType) ?? property.PropertyType;
+        if (!enumType.IsEnum)
+        {
+            result = default;
+            return false;
+        }
+
+        if (enumMode == EnumParseFailureMode.Throw)
+        {
+            result = default;
+            return false;
+        }
+
+        switch (enumMode)
+        {
+            case EnumParseFailureMode.SetNullAndLog:
+                TypeCoercionHelper.Logger.LogWarning(
+                    exception,
+                    "Failed to coerce value '{Value}' to enum property {Property} of type {EnumType}.",
+                    value,
+                    property.Name,
+                    enumType);
+                if (Nullable.GetUnderlyingType(property.PropertyType) != null)
+                {
+                    result = null;
+                    return true;
+                }
+
+                var fallback = Activator.CreateInstance(Enum.GetUnderlyingType(enumType))!;
+                result = Enum.ToObject(enumType, fallback);
+                return true;
+            case EnumParseFailureMode.SetDefaultValue:
+                var defaultValue = Activator.CreateInstance(Enum.GetUnderlyingType(enumType))!;
+                result = Enum.ToObject(enumType, defaultValue);
+                return true;
+            default:
+                result = null;
+                return false;
+        }
+    }
+
+    private readonly record struct SetterCacheKey(
+        PropertyInfo Property,
+        Type FieldType,
+        bool RequiresCoercion,
+        EnumParseFailureMode EnumMode,
+        int Ordinal);
+
+    private readonly record struct PropertyLookupCacheKey(Type Type, bool ColumnsOnly);
 
     private sealed record MapperPlan(
         int[] Ordinals,
         PropertyInfo[] Properties,
-        Action<object, object?>[] Setters,
-        Func<object, object?>[] Coercers);
+        Action<object, DbDataReader>[] Setters);
+
+    private static IReadOnlyDictionary<string, PropertyInfo> GetPropertyLookup(Type type, MapperOptions options)
+    {
+        var key = new PropertyLookupCacheKey(type, options.ColumnsOnly);
+        return _propertyLookupCache.GetOrAdd(key, static cacheKey => BuildPropertyLookup(cacheKey));
+    }
+
+    private static IReadOnlyDictionary<string, PropertyInfo> BuildPropertyLookup(PropertyLookupCacheKey cacheKey)
+    {
+        var properties = cacheKey.Type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.SetProperty);
+        var comparer = StringComparer.OrdinalIgnoreCase;
+        var lookup = new Dictionary<string, PropertyInfo>(properties.Length, comparer);
+
+        for (var i = 0; i < properties.Length; i++)
+        {
+            var property = properties[i];
+            var setMethod = property.SetMethod;
+            if (setMethod == null || !setMethod.IsPublic || setMethod.IsStatic)
+            {
+                continue;
+            }
+
+            string lookupKey;
+            if (cacheKey.ColumnsOnly)
+            {
+                var column = property.GetCustomAttribute<ColumnAttribute>();
+                if (column == null)
+                {
+                    continue;
+                }
+
+                lookupKey = column.Name;
+            }
+            else
+            {
+                lookupKey = property.Name;
+            }
+
+            if (!lookup.TryAdd(lookupKey, property))
+            {
+                throw new ArgumentException(
+                    $"Duplicate column mapping detected for '{lookupKey}' on type '{cacheKey.Type.FullName}'.");
+            }
+        }
+
+        return lookup;
+    }
+
+    private static MethodInfo ResolveGetFieldValueMethod()
+    {
+        var methods = typeof(DbDataReader).GetMethods(BindingFlags.Instance | BindingFlags.Public);
+        for (var i = 0; i < methods.Length; i++)
+        {
+            var method = methods[i];
+            if (method.IsGenericMethodDefinition && method.Name == nameof(DbDataReader.GetFieldValue))
+            {
+                return method;
+            }
+        }
+
+        throw new InvalidOperationException("DbDataReader.GetFieldValue<T> method not found.");
+    }
 }
 

--- a/pengdows.crud/TypeCoercionHelper.cs
+++ b/pengdows.crud/TypeCoercionHelper.cs
@@ -33,8 +33,6 @@ public sealed record TypeCoercionOptions(TimeMappingPolicy TimePolicy, JsonPassT
 
 public static class TypeCoercionHelper
 {
-    private static readonly char[] TrueChars = { 't', 'y', '1' };
-    private static readonly char[] FalseChars = { 'f', 'n', '0' };
     private static readonly Type GuidType = typeof(Guid);
     private static readonly Type GuidArrayType = typeof(byte[]);
     private static readonly Type ReadOnlyMemoryOfByteType = typeof(ReadOnlyMemory<byte>);
@@ -286,17 +284,19 @@ public static class TypeCoercionHelper
 
     private static bool EvaluateCharBoolean(char lower)
     {
-        if (Array.IndexOf(TrueChars, lower) >= 0)
+        switch (lower)
         {
-            return true;
+            case 't':
+            case 'y':
+            case '1':
+                return true;
+            case 'f':
+            case 'n':
+            case '0':
+                return false;
+            default:
+                throw new InvalidCastException($"Cannot convert character '{lower}' to Boolean.");
         }
-
-        if (Array.IndexOf(FalseChars, lower) >= 0)
-        {
-            return false;
-        }
-
-        throw new InvalidCastException($"Cannot convert character '{lower}' to Boolean.");
     }
 
     private static object CoerceDateTimeOffset(object value, TypeCoercionOptions options)


### PR DESCRIPTION
## Summary
- include the resolved field types when building the data reader schema hash so cached plans rebuild when column types change
- add strict tracking fake readers and tests that cover both stable and changing column type scenarios to prevent stale typed getters from being reused
- cache per-type property lookup dictionaries so DataReaderMapper avoids repeated reflection and guards against duplicate column annotations
- extend mapper tests to cover switching ColumnsOnly modes and duplicate column attribute failures, ensuring the cache respects options

## Testing
- `dotnet test -c Release` *(fails: dotnet command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d95723e5e0832580b55db79ad024a2