### PR TITLE
Fix DataReaderMapper plan cache key to avoid retaining options

### DIFF
--- a/pengdows.crud.Tests/DataReaderMapperTests.cs
+++ b/pengdows.crud.Tests/DataReaderMapperTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Reflection;
 using System.Threading.Tasks;
 using pengdows.crud.attributes;
 using pengdows.crud.fakeDb;
@@ -257,6 +258,113 @@ public class DataReaderMapperTests
 
         await Assert.ThrowsAsync<InvalidOperationException>(
             () => DataReaderMapper.LoadAsync<EnumEntity>(reader, new MapperOptions(Strict: true)));
+    }
+
+    [Fact]
+    public async Task LoadAsync_ReusesPlan_ForEquivalentOptions()
+    {
+        var readerFactory = () => new fakeDbDataReader(new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["Name"] = "Jane"
+            }
+        });
+
+        var initialCount = GetPlanCacheCount();
+
+        await DataReaderMapper.LoadAsync<SampleEntity>(readerFactory(), new MapperOptions());
+
+        var afterFirstLoad = GetPlanCacheCount();
+        Assert.Equal(initialCount + 1, afterFirstLoad);
+
+        await DataReaderMapper.LoadAsync<SampleEntity>(readerFactory(), new MapperOptions());
+
+        var afterSecondLoad = GetPlanCacheCount();
+        Assert.Equal(afterFirstLoad, afterSecondLoad);
+    }
+
+    [Fact]
+    public async Task LoadAsync_DifferentNamePolicies_CreateDistinctPlans()
+    {
+        var readerFactory = () => new fakeDbDataReader(new[]
+        {
+            new Dictionary<string, object>
+            {
+                ["first_name"] = "Jane"
+            }
+        });
+
+        var initialCount = GetPlanCacheCount();
+
+        var snakeToPascal = new MapperOptions(NamePolicy: name =>
+        {
+            if (name.Equals("first_name", StringComparison.OrdinalIgnoreCase))
+            {
+                return "FirstName";
+            }
+
+            return name;
+        });
+
+        await DataReaderMapper.LoadAsync<SnakeEntity>(readerFactory(), snakeToPascal);
+
+        var afterFirstLoad = GetPlanCacheCount();
+        Assert.Equal(initialCount + 1, afterFirstLoad);
+
+        var underscoreStrip = new MapperOptions(NamePolicy: name => name.Replace("_", string.Empty));
+
+        await DataReaderMapper.LoadAsync<SnakeEntity>(readerFactory(), underscoreStrip);
+
+        var afterSecondLoad = GetPlanCacheCount();
+        Assert.Equal(afterFirstLoad + 1, afterSecondLoad);
+    }
+
+    [Fact]
+    public async Task LoadAsync_CapturingNamePolicyOptions_AreCollectible()
+    {
+        WeakReference? weakOptions = null;
+
+        async Task CreatePlanAsync()
+        {
+            var capture = Guid.NewGuid().ToString();
+            var options = new MapperOptions(NamePolicy: name =>
+            {
+                _ = capture;
+                return name;
+            });
+
+            weakOptions = new WeakReference(options);
+
+            var reader = new fakeDbDataReader(new[]
+            {
+                new Dictionary<string, object>
+                {
+                    ["Name"] = "Jane"
+                }
+            });
+
+            await DataReaderMapper.LoadAsync<SampleEntity>(reader, options);
+        }
+
+        await CreatePlanAsync();
+
+        for (var i = 0; i < 3; i++)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+
+        Assert.NotNull(weakOptions);
+        Assert.False(weakOptions!.IsAlive);
+    }
+
+    private static int GetPlanCacheCount()
+    {
+        var cacheField = typeof(DataReaderMapper).GetField("_planCache", BindingFlags.Static | BindingFlags.NonPublic);
+        var cache = cacheField!.GetValue(null)!;
+        var countProperty = cache.GetType().GetProperty("Count");
+        return (int)countProperty!.GetValue(cache)!;
     }
 
     private class SampleEntity


### PR DESCRIPTION
## Summary
- replace the DataReaderMapper plan cache tuple with a value-type PlanCacheKey that avoids rooting MapperOptions
- incorporate normalized names, ColumnsOnly, and EnumMode into the schema hash used by the cache
- add unit tests covering plan reuse, NamePolicy variations, and GC collection of short-lived options

## Testing
- dotnet test -c Release *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d96464cfa0832587c2d73f72a00b1e