### PR TITLE
Add coverage summary documentation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,82 @@
+name: Unit Tests and Coverage
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  test:
+    name: Run unit tests and collect coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Restore dependencies
+        run: dotnet restore pengdows.crud.sln
+
+      - name: Run unit tests with coverage
+        run: >-
+          dotnet test pengdows.crud.Tests/pengdows.crud.Tests.csproj
+          -c Release
+          --logger "trx;LogFileName=unit-tests.trx"
+          --results-directory TestResults
+          --settings coverage.runsettings
+
+      - name: Install ReportGenerator
+        run: |
+          dotnet tool install --global dotnet-reportgenerator-globaltool
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+
+      - name: Create coverage summary
+        run: >-
+          reportgenerator
+          -reports:"TestResults/**/coverage.cobertura.xml"
+          -targetdir:"coverage-report"
+          -reporttypes:"TextSummary;Html"
+          -assemblyfilters:"+pengdows.crud;-pengdows.crud.Tests;-pengdows.crud.abstractions;-pengdows.crud.fakeDb;-testbed"
+          -classfilters:"-*Test*;-*Mock*"
+
+      - name: Publish coverage summary
+        run: |
+          echo '### Code Coverage Summary' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat coverage-report/Summary.txt >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: TestResults/**/*.trx
+
+      - name: Upload coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            coverage-report
+            TestResults/**/*.xml
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v4
+        with:
+          files: TestResults/**/coverage.cobertura.xml
+          disable_search: true
+          fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/docs/coverage-report.md
+++ b/docs/coverage-report.md
@@ -1,0 +1,61 @@
+# Unit Test Coverage Report
+
+This document captures the most recent coverage data generated for the `pengdows.crud` solution. The measurements come from `coverage.json`, which was produced by DotCover `2025.2.0.1`.
+
+## How to run the unit tests with coverage
+
+From the repository root, execute the following command:
+
+```bash
+dotnet test pengdows.crud.Tests/pengdows.crud.Tests.csproj \
+  -c Release \
+  --settings coverage.runsettings \
+  --results-directory TestResults
+```
+
+The runsettings file excludes the test projects and helpers from the coverage calculation so the reported metrics focus on the production assemblies.
+
+## Coverage summary
+
+Overall coverage: **86%** (2467 / 2858 statements).
+
+| Namespace | Covered Statements | Total Statements | Coverage |
+| --- | --- | --- | --- |
+| attributes | 30 | 35 | 86% |
+| configuration | 88 | 95 | 93% |
+| connection | 59 | 65 | 91% |
+| dialects | 557 | 718 | 78% |
+| exceptions | 15 | 15 | 100% |
+| infrastructure | 27 | 27 | 100% |
+| isolation | 36 | 37 | 97% |
+| tenant | 53 | 56 | 95% |
+| threading | 33 | 33 | 100% |
+| wrappers | 128 | 142 | 90% |
+
+The root `pengdows.crud` namespace also exposes several direct types. Their individual coverage is outlined below:
+
+| Type | Covered Statements | Total Statements | Coverage |
+| --- | --- | --- | --- |
+| AuditValueResolver | 0 | 0 | 0% |
+| AuditValues | 6 | 6 | 100% |
+| ColumnInfo | 45 | 46 | 98% |
+| DataReaderMapper | 32 | 32 | 100% |
+| DataSourceInformation | 59 | 59 | 100% |
+| DatabaseContext | 140 | 153 | 92% |
+| DecimalHelpers | 9 | 9 | 100% |
+| EntityHelper&lt;TEntity, TRowID&gt; | 491 | 583 | 84% |
+| EphemeralSecureString | 57 | 58 | 98% |
+| ReflectionSerializer | 67 | 74 | 91% |
+| SqlContainer | 116 | 148 | 78% |
+| SqlContainerExtensions | 2 | 2 | 100% |
+| StubAuditValueResolver | 4 | 4 | 100% |
+| TableInfo | 20 | 20 | 100% |
+| TransactionContext | 122 | 136 | 90% |
+| TypeCoercionHelper | 35 | 39 | 90% |
+| TypeMapRegistry | 104 | 104 | 100% |
+| Utils | 24 | 26 | 92% |
+| Uuid7Optimized | 108 | 136 | 79% |
+
+## Environment note
+
+Running the coverage command above requires the .NET SDK to be available on the execution environment. If the SDK is missing you can install it by following the guidance at <https://learn.microsoft.com/dotnet/core/install/>.


### PR DESCRIPTION
## Summary
- add documentation describing how to execute the pengdows.crud unit test suite with coverage
- capture the latest coverage metrics from coverage.json for quick reference
- note the requirement to have the .NET SDK installed before running the coverage command
- add a GitHub Actions workflow that runs the pengdows.crud.Tests suite with coverage, publishes artifacts, and uploads metrics to Codecov

## Testing
- dotnet test pengdows.crud.Tests/pengdows.crud.Tests.csproj -c Release --settings coverage.runsettings --results-directory TestResults *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68daa7fd521083259b06b948c10f01e5