### PR TITLE
Fix build of verify-novendor tool before execution

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,7 +1,10 @@
 <Project>
   <!-- Vendor reference verification target - only runs for core assemblies -->
   <Target Name="VerifyNoVendor" AfterTargets="Build" Condition="'$(SkipVerifyNoVendor)' != 'true' And '$(MSBuildProjectName)' != 'testbed' And '$(MSBuildProjectName)' != 'CrudBenchmarks' And '$(MSBuildProjectName)' != 'pengdows.crud.Tests' And '$(MSBuildProjectName)' != 'verify-novendor' And !$(MSBuildProjectDirectory.Contains('testbed')) And !$(MSBuildProjectDirectory.Contains('benchmarks')) And !$(MSBuildProjectDirectory.Contains('Tests'))">
-  <Exec Command="dotnet &quot;$(MSBuildThisFileDirectory)tools/verify-novendor/bin/Debug/net8.0/verify-novendor.dll&quot; &quot;$(TargetDir)&quot;" 
+  <MSBuild Projects="$(MSBuildThisFileDirectory)tools/verify-novendor/verify-novendor.csproj"
+           Targets="Build"
+           Properties="Configuration=Debug" />
+  <Exec Command="dotnet &quot;$(MSBuildThisFileDirectory)tools/verify-novendor/bin/Debug/net8.0/verify-novendor.dll&quot; &quot;$(TargetDir)&quot;"
         ContinueOnError="false"
         IgnoreExitCode="false" />
   </Target>


### PR DESCRIPTION
## Summary
- ensure the VerifyNoVendor target builds the verify-novendor tool before invoking it so CI can locate the DLL

## Testing
- dotnet build pengdows.crud.sln -c Release *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a62bb2d08325add4af51985f1c65