### PR TITLE
fix: build interface api check before validation

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -10,6 +10,9 @@
   </Target>
 
   <Target Name="ValidateInterfaceBaseline" AfterTargets="Build" Condition="'$(MSBuildProjectName)' == 'pengdows.crud.abstractions'">
+    <MSBuild Projects="$(MSBuildThisFileDirectory)tools/interface-api-check/InterfaceApiCheck.csproj"
+             Targets="Build"
+             Properties="Configuration=Release" />
     <Exec Command="dotnet &quot;$(MSBuildThisFileDirectory)tools/interface-api-check/bin/Release/net8.0/InterfaceApiCheck.dll&quot; --verify --assembly &quot;$(TargetPath)&quot; --baseline &quot;$(MSBuildProjectDirectory)/ApiBaseline/interfaces.txt&quot;" />
   </Target>
 </Project>


### PR DESCRIPTION
## Summary
- ensure the interface API check tool is built in Release before the validation target runs

## Testing
- dotnet build pengdows.crud.sln -c Release *(fails: `dotnet` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b3c366e88325a208812fd9f65fbb