### PR TITLE
fix: restore interface api check tool during build

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -11,8 +11,8 @@
 
   <Target Name="ValidateInterfaceBaseline" AfterTargets="Build" Condition="'$(MSBuildProjectName)' == 'pengdows.crud.abstractions'">
     <MSBuild Projects="$(MSBuildThisFileDirectory)tools/interface-api-check/InterfaceApiCheck.csproj"
-             Targets="Build"
-             Properties="Configuration=Release" />
+             Targets="Restore;Build"
+             Properties="Configuration=Release;NoRestore=false" />
     <Exec Command="dotnet &quot;$(MSBuildThisFileDirectory)tools/interface-api-check/bin/Release/net8.0/InterfaceApiCheck.dll&quot; --verify --assembly &quot;$(TargetPath)&quot; --baseline &quot;$(MSBuildProjectDirectory)/ApiBaseline/interfaces.txt&quot;" />
   </Target>
 </Project>


### PR DESCRIPTION
## Summary
- ensure the interface API check tool runs an explicit restore before building so the baseline validation target can run under --no-restore builds

## Testing
- dotnet build --no-restore --configuration Release *(fails: `dotnet` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b4b7cff88325a32f5bf8240125fd