### PR TITLE
Fix probe connection null handling and nullability warnings

### DIFF
--- a/benchmarks/CrudBenchmarks/AdvancedTypeBenchmarks.cs
+++ b/benchmarks/CrudBenchmarks/AdvancedTypeBenchmarks.cs
@@ -154,9 +154,9 @@ public class AdvancedTypeBenchmarks
         public override DbType DbType { get; set; }
         public override ParameterDirection Direction { get; set; }
         public override bool IsNullable { get; set; }
-        public override string ParameterName { get; set; } = string.Empty;
+        public override string? ParameterName { get; set; } = string.Empty;
         public override int Size { get; set; }
-        public override string SourceColumn { get; set; } = string.Empty;
+        public override string? SourceColumn { get; set; } = string.Empty;
         public override bool SourceColumnNullMapping { get; set; }
         public override object? Value { get; set; }
 

--- a/pengdows.crud/TypeCoercionHelper.cs
+++ b/pengdows.crud/TypeCoercionHelper.cs
@@ -171,7 +171,7 @@ public static class TypeCoercionHelper
         }
     }
 
-    private static object CoerceEnum(object value, Type enumType, EnumParseFailureMode parseMode, Type targetType)
+    private static object? CoerceEnum(object value, Type enumType, EnumParseFailureMode parseMode, Type targetType)
     {
         if (enumType.IsInstanceOfType(value))
         {


### PR DESCRIPTION
## Summary
- update enum coercion helper to return nullable values when fallbacks request nulls
- guard DatabaseContext initialization paths when the probe connection cannot open and tighten pooling configuration checks
- align benchmark parameter overrides with base nullability and cover probe failures with constructor tests

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1b84b180c8325b0a10f2f8d1d5754