### PR TITLE
Fix DataReaderMapper coercion for advanced types

### DIFF
--- a/pengdows.crud.abstractions/MapperOptions.cs
+++ b/pengdows.crud.abstractions/MapperOptions.cs
@@ -10,8 +10,11 @@ public sealed record MapperOptions(
     bool Strict = false,
     bool ColumnsOnly = false,
     Func<string, string>? NamePolicy = null,
-    EnumParseFailureMode EnumMode = EnumParseFailureMode.Throw)
+    EnumParseFailureMode EnumMode = EnumParseFailureMode.Throw,
+    TypeCoercionOptions? CoercionOptions = null)
 {
     public static readonly MapperOptions Default = new();
+
+    public TypeCoercionOptions EffectiveCoercionOptions => CoercionOptions ?? TypeCoercionOptions.Default;
 }
 


### PR DESCRIPTION
## Summary
- add a coercion option slot to `MapperOptions` so mappers can carry the active provider
- propagate the effective coercion options through `DataReaderMapper` cache keys and setters to reach `TypeCoercionHelper`
- extend the mapper tests with positive and negative coverage for PostgreSQL inet values

## Testing
- `dotnet test -c Release` *(fails: dotnet is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1bddc9fd483258a1235163477cab1